### PR TITLE
Add input and constraint translation to MLIR

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -913,4 +913,43 @@ def UndefOp : Btor_Op<"undef"> {
     let assemblyFormat = "attr-dict `:` type($result)";
 }
 
+def InputOp : Btor_Op<"input"> {
+    let summary = "btor input";
+    let description = [{
+        This operation takes an input number and a
+        SignlessIntegerLike, then returns the 
+        received SignlessIntegerLike
+
+        Example:
+
+        ```mlir
+        // invoke the input operation to %0
+        %0 = btor.input 15, %some_i3_value : i3
+        ```
+
+        In the example above, 15 gets interpreted as an
+        i64 integer, while %some_i3_value is expected 
+        to be of type i3. 
+    }];
+
+    let arguments = (ins AnyI64Attr:$id, SignlessIntegerLike:$value);
+    let results = (outs SignlessIntegerLike:$result);
+
+    let builders = [
+        OpBuilder<(ins "Value":$value),
+        [{
+            $_state.addOperands({value});
+            $_state.addTypes(value.getType());
+        }]>
+    ];
+
+    let printer = [{
+      return printInputOp(p, *this);
+    }];
+
+    let parser = [{
+      return parseInputOp(parser, result);
+    }];
+}
+
 #endif // BTOR_OPS

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -258,5 +258,39 @@ static LogicalResult verifyConcatOp(Op op) {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Input Operation
+//===----------------------------------------------------------------------===//
+
+static void printInputOp(OpAsmPrinter &p, mlir::btor::InputOp &op) {
+    p << " "  << op.value() << " : " << op->getOperand(0).getType();
+    p << " ";
+    p.printOptionalAttrDict(op->getAttrs());
+}
+
+static ParseResult parseInputOp(OpAsmParser &parser,OperationState &result) {  
+    SmallVector<OpAsmParser::OperandType> ops;
+    NamedAttrList attrs;
+    Attribute idAttr;
+    Type type;
+
+    if (parser.parseAttribute(idAttr, "id", attrs) ||
+        parser.parseComma() ||
+        parser.parseOperandList(ops, 1) ||
+        parser.parseOptionalAttrDict(attrs) || 
+        parser.parseColonType(type) ||
+        parser.resolveOperands(ops, type, result.operands)
+        )
+        return failure();
+
+    if (!idAttr.isa<mlir::IntegerAttr>())
+        return parser.emitError(parser.getNameLoc(),
+                                "expected integer id attribute");
+
+    result.attributes = attrs;
+    result.addTypes({type});
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"


### PR DESCRIPTION
Convert from the btor2 file below
```
1 sort bitvec 1
2 input 1 turn
3 state 1 state0
4 state 1 state1
5 ite 1 -2 -3 3
6 ite 1 2 -4 4
7 next 1 3 5
8 next 1 4 6
9 eq 1 3 4
10 one 1
11 state 1 initially
12 init 1 11 10
13 zero 1
14 next 1 11 13
15 implies 1 11 -9
16 constraint 15
17 bad 9
```
to the MLIR module:
```
module  {
  func @init() -> (i1, i1, i1) {
    %0 = btor.const true
    %1 = btor.undef : i1
    return %1, %1, %0 : i1, i1, i1
  }
  func @next(%arg0: i1, %arg1: i1, %arg2: i1) -> (i1, i1, i1) {
    %0 = btor.not %arg0 : i1
    %1 = btor.const false
    %2 = btor.input %1 : i1  {id = 0 : i64}
    %3 = btor.not %2 : i1
    %4 = btor.ite %3, %0, %arg0 : i1
    %5 = btor.not %arg1 : i1
    %6 = btor.ite %2, %5, %arg1 : i1
    %7 = btor.const false
    %8 = btor.cmp eq, %arg0, %arg1 : i1
    %9 = btor.not %8 : i1
    %10 = btor.implies %arg2, %9 : i1
    btor.assume(%10)
    btor.assert_not(%8)
    return %4, %6, %7 : i1, i1, i1
  }
}
```