### PR TITLE
feat: use vector types for ops

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -925,14 +925,21 @@ def ArrayOp : Btor_Op<"nd_array"> {
     bitvec -> bitvec. For example:
 
     ```mlir
-    %0 = btor.nd_array : !btor.array<i8,i32>
+    %0 = btor.nd_array : vector<8,i32>
     ```
 
     This operation returns a single SSA value of a btor array type used
     by subsequent read and write operations. 
   }];
 
-  let results = (outs Btor_Array:$result);
+  let extraClassDeclaration = [{
+    VectorType getArrayType() {
+      return result().getType().cast<VectorType>();
+    }
+  }];
+
+  let results = (outs AnyVector:$result);
+  let hasVerifier = 1;
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 
@@ -945,15 +952,21 @@ def InitArrayOp : Btor_Op<"array"> {
     For example:
 
     ```mlir
-    %4 = btor.array %1 : !btor.array<i8,i32>
+    %4 = btor.array %1 : vector<8,i32>
     ```
 
     This operation returns a single SSA value of a btor array type used
     by subsequent read and write operations. 
   }];
 
+  let extraClassDeclaration = [{
+    VectorType getArrayType() {
+      return result().getType().cast<VectorType>();
+    }
+  }];
+
   let arguments = (ins SignlessIntegerLike:$init);
-  let results = (outs Btor_Array:$result);
+  let results = (outs AnyVector:$result);
   // let assemblyFormat = "$init attr-dict `:` type($result)";
   let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
@@ -969,16 +982,16 @@ def ReadOp : Btor_Op<"read"> {
     Example:
 
     ```mlir
-    %1 = btor.read %A[%0] : !btor.array<i8,i32>, i32
+    %1 = btor.read %A[%0] : vector<8,i32>, i32
     ```
   }];
 
-  let arguments = (ins Btor_Array:$base, SignlessIntegerLike:$index);
+  let arguments = (ins AnyVector:$base, SignlessIntegerLike:$index);
   let results = (outs SignlessIntegerLike:$result);
 
   let extraClassDeclaration = [{
-    ArrayType getArrayType() {
-      return base().getType().cast<ArrayType>();
+    VectorType getArrayType() {
+      return base().getType().cast<VectorType>();
     }
   }];
 
@@ -999,13 +1012,13 @@ def WriteOp : Btor_Op<"write"> {
     ```
   }];
 
-  let arguments = (ins SignlessIntegerLike:$value, Btor_Array:$base,
+  let arguments = (ins SignlessIntegerLike:$value, AnyVector:$base,
                        SignlessIntegerLike:$index);
 
-  let results = (outs Btor_Array:$result);
-    let extraClassDeclaration = [{
-    ArrayType getArrayType() {
-      return base().getType().cast<ArrayType>();
+  let results = (outs AnyVector:$result);
+  let extraClassDeclaration = [{
+    VectorType getArrayType() {
+      return base().getType().cast<VectorType>();
     }
   }];
 

--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -137,11 +137,10 @@ private:
   // Builder wrappers
   Type getTypeOf(Btor2Line *line) {
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
-      auto indexType = m_builder.getIntegerType(
-          m_sorts.at(line->sort.array.index)->sort.bitvec.width);
+      unsigned indexWidth = pow(2, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
       auto elementType = m_builder.getIntegerType(
           m_sorts.at(line->sort.array.element)->sort.bitvec.width);
-      return btor::ArrayType::get(m_context, indexType, elementType);
+      return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
       ;
     }
     return m_builder.getIntegerType(line->sort.bitvec.width);
@@ -315,7 +314,7 @@ private:
 
   // Array Operations
   Operation *buildReadOp(const Value &array, const Value &index) {
-    auto elementType = array.getType().cast<ArrayType>().getElementType();
+    auto elementType = array.getType().cast<VectorType>().getElementType();
     auto res =
         m_builder.create<btor::ReadOp>(m_unknownLoc, elementType, array, index);
     return res;


### PR DESCRIPTION
Unblocking work so that we can generate the rest of our pipeline

Having custom types makes conversion between dialects harder. I implemented what we've learnt about customizing operations to get a vector type that doesn't need an index type yet. This should make converting operations easier since the type will remain constant

Thus, given the following `btor2` input, that uses arrays:
```
1 sort bitvec 4
2 sort array 1 1
3 one 1
4 constd 1 8
5 state 2
6 init 2 5 3
7 read 1 5 4
8 one 1
9 add 1 7 8
10 write 2 5 4 9
11 next 2 5 10
12 ones 1
13 sort bitvec 1
14 eq 13 7 12
15 bad 14
```

we take 2^{bitvec width} as the size of our vector. This gives us the mlir representation below:
```
module {
  func.func @main() {
    %0 = btor.constant 1 : i4
    %1 = btor.array %0 : vector<16xi4>
    cf.br ^bb1(%1 : vector<16xi4>)
  ^bb1(%2: vector<16xi4>):  // 2 preds: ^bb0, ^bb1
    %3 = btor.constant 1 : i4
    %4 = btor.constant -8 : i4
    %5 = btor.read %2[%4] : vector<16xi4>, i4
    %6 = btor.add %5, %3 : i4
    %7 = btor.write %6, %2[%4] : vector<16xi4>
    %8 = btor.constant -1 : i4
    %9 = btor.cmp eq, %5, %8 : i4
    btor.assert_not(%9)
    cf.br ^bb1(%7 : vector<16xi4>)
  }
}

```
