### PR TITLE
Fix nd init

### DIFF
--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -129,6 +129,7 @@ class Deserialize {
   void toOp(Btor2Line *line);
   bool needsMLIROp(Btor2Line * line);
   bool hasReturnValue(Btor2Line * line);
+  bool isStateArgumentOfInitOp(Btor2Line * cur, Btor2Line * argument);
   void createNegateLine(int64_t curAt, const unsigned lineId, const Value &child);
   Operation * createMLIR(const Btor2Line *line, 
                         const SmallVector<Value> &kids,

--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -101,7 +101,7 @@ class Deserialize {
   std::vector<Btor2Line *> m_constraints;
   std::vector<Btor2Line *> m_lines;
 
-  std::map<int64_t, Btor2Line *> m_inits;
+  std::map<int64_t, Btor2Line *> m_inits; // lets us quickly find the initLine from state->init
   std::map<int64_t, Value> m_cache;
   std::map<int64_t, Btor2Line *> m_sorts;
   std::map<unsigned, unsigned> m_inputs; // lineId -> input #

--- a/lib/Conversion/BtorToArithmetic/BtorToArithmetic.cpp
+++ b/lib/Conversion/BtorToArithmetic/BtorToArithmetic.cpp
@@ -305,7 +305,6 @@ LogicalResult NotLowering::matchAndRewrite(mlir::btor::NotOp notOp,
   Value operand = notOp.operand();
   Type opType = operand.getType();
 
-  int width = opType.getIntOrFloatBitWidth();
   int trueVal = -1;
   Value trueConst = rewriter.create<arith::ConstantOp>(
       notOp.getLoc(), opType, rewriter.getIntegerAttr(opType, trueVal));


### PR DESCRIPTION
There was code that would ensure btor2 states are initialized in order of appearance to avoid using a nd value when an initialization exists later in the btor file. We found that this was clashing with the default nd value so the pr fixes the issue