### PR TITLE
feat: custom types and attributes infrastructure

### DIFF
--- a/include/Dialect/Btor/IR/Btor.h
+++ b/include/Dialect/Btor/IR/Btor.h
@@ -9,8 +9,8 @@
 #ifndef BTOR_IR_BTOR_H
 #define BTOR_IR_BTOR_H
 
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
@@ -41,5 +41,10 @@
 
 #include "Dialect/Btor/IR/BtorTypes.h"
 
+//===----------------------------------------------------------------------===//
+// Btor Dialect Attributes
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/Btor/IR/BtorAttributes.h"
 
 #endif // BTOR_IR_BTOR_H

--- a/include/Dialect/Btor/IR/Btor.h
+++ b/include/Dialect/Btor/IR/Btor.h
@@ -35,5 +35,11 @@
 #define GET_OP_CLASSES
 #include "Dialect/Btor/IR/BtorOps.h.inc"
 
+//===----------------------------------------------------------------------===//
+// Btor Dialect Types
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/Btor/IR/BtorTypes.h"
+
 
 #endif // BTOR_IR_BTOR_H

--- a/include/Dialect/Btor/IR/BtorAttributes.h
+++ b/include/Dialect/Btor/IR/BtorAttributes.h
@@ -1,0 +1,30 @@
+//===- BtorAttrs.h - Btor dialect ops -----------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BTOR_IR_BTOR_ATTRS_H
+#define BTOR_IR_BTOR_ATTRS_H
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+
+//===----------------------------------------------------------------------===//
+// Btor Dialect Attributes
+//===----------------------------------------------------------------------===//
+
+#define GET_ATTRDEF_CLASSES
+#include "Dialect/Btor/IR/BtorAttributes.h.inc"
+
+using namespace mlir;
+using namespace mlir::btor;
+
+#endif // BTOR_IR_BTOR_ATTRS_H

--- a/include/Dialect/Btor/IR/BtorAttributes.td
+++ b/include/Dialect/Btor/IR/BtorAttributes.td
@@ -1,0 +1,46 @@
+#ifndef BTOR_ATTRS
+#define BTOR_ATTRS
+
+include "mlir/IR/EnumAttr.td"
+include "BtorBase.td"
+
+//===----------------------------------------------------------------------===//
+// btor constants definition.
+//===----------------------------------------------------------------------===//
+
+def BTOR_EQ  : I64EnumAttrCase<"eq", 0>;
+def BTOR_NE  : I64EnumAttrCase<"ne", 1>;
+def BTOR_SLT : I64EnumAttrCase<"slt", 2>;
+def BTOR_SLE : I64EnumAttrCase<"sle", 3>;
+def BTOR_SGT : I64EnumAttrCase<"sgt", 4>;
+def BTOR_SGE : I64EnumAttrCase<"sge", 5>;
+def BTOR_ULT : I64EnumAttrCase<"ult", 6>;
+def BTOR_ULE : I64EnumAttrCase<"ule", 7>;
+def BTOR_UGT : I64EnumAttrCase<"ugt", 8>;
+def BTOR_UGE : I64EnumAttrCase<"uge", 9>;
+
+def BtorPredicateAttr : I64EnumAttr<
+    "BtorPredicate", "btor.cmp comparison predicate",
+    [BTOR_EQ, BTOR_NE, BTOR_SLT, BTOR_SLE, BTOR_SGT,
+     BTOR_SGE, BTOR_ULT, BTOR_ULE, BTOR_UGT, BTOR_UGE]> {
+  let cppNamespace = "::mlir::btor";
+}
+
+//===----------------------------------------------------------------------===//
+// btor attributes definition.
+//===----------------------------------------------------------------------===//
+
+class Btor_Attr<string name, string attrMnemonic, list<Trait> traits = [], string baseCppClass = "::mlir::Attribute">
+    : AttrDef<Btor_Dialect, name, traits, baseCppClass> {
+  let mnemonic = attrMnemonic;
+}
+
+def BitVecAttribute : Btor_Attr<"BitVec", "bvattr"> {
+  let summary = "bit vector attribute";
+  let description = [{
+    Bit vector attribute
+  }];
+  let parameters = (ins "BitVecType":$type, "APInt":$value);   
+}
+
+#endif // BTOR_ATTRS

--- a/include/Dialect/Btor/IR/BtorBase.td
+++ b/include/Dialect/Btor/IR/BtorBase.td
@@ -42,6 +42,12 @@ def Btor_Dialect : Dialect {
     let name = "btor";
     let summary = "A BTOR2 MLIR dialect";
     let cppNamespace = "::mlir::btor";
+    let extraClassDeclaration = [{
+    private:
+            // Register the custom btor Types.
+            void registerTypes();
+    public:
+    }];
 }
 
 #endif // BTOR_DIALECT

--- a/include/Dialect/Btor/IR/BtorBase.td
+++ b/include/Dialect/Btor/IR/BtorBase.td
@@ -9,30 +9,7 @@
 #ifndef BTOR_BASE
 #define BTOR_BASE
 
-include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
-
-//===----------------------------------------------------------------------===//
-// btor constants definition.
-//===----------------------------------------------------------------------===//
-
-def BTOR_EQ  : I64EnumAttrCase<"eq", 0>;
-def BTOR_NE  : I64EnumAttrCase<"ne", 1>;
-def BTOR_SLT : I64EnumAttrCase<"slt", 2>;
-def BTOR_SLE : I64EnumAttrCase<"sle", 3>;
-def BTOR_SGT : I64EnumAttrCase<"sgt", 4>;
-def BTOR_SGE : I64EnumAttrCase<"sge", 5>;
-def BTOR_ULT : I64EnumAttrCase<"ult", 6>;
-def BTOR_ULE : I64EnumAttrCase<"ule", 7>;
-def BTOR_UGT : I64EnumAttrCase<"ugt", 8>;
-def BTOR_UGE : I64EnumAttrCase<"uge", 9>;
-
-def BtorPredicateAttr : I64EnumAttr<
-    "BtorPredicate", "btor.cmp comparison predicate",
-    [BTOR_EQ, BTOR_NE, BTOR_SLT, BTOR_SLE, BTOR_SGT,
-     BTOR_SGE, BTOR_ULT, BTOR_ULE, BTOR_UGT, BTOR_UGE]> {
-  let cppNamespace = "::mlir::btor";
-}
 
 //===----------------------------------------------------------------------===//
 // Btor dialect definition.
@@ -46,6 +23,9 @@ def Btor_Dialect : Dialect {
     private:
             // Register the custom btor Types.
             void registerTypes();
+
+            // Register the custom btor attributes.
+            void registerAttrs();
     public:
     }];
 }

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -16,6 +16,7 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/VectorInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
+include "Dialect/Btor/IR/BtorTypes.td"
 
 
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -17,6 +17,7 @@ include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/VectorInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "Dialect/Btor/IR/BtorTypes.td"
+include "Dialect/Btor/IR/BtorAttributes.td"
 
 
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/Btor/IR/BtorTypes.h
+++ b/include/Dialect/Btor/IR/BtorTypes.h
@@ -1,0 +1,29 @@
+//===- BtorTypes.h - Btor dialect ops -----------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BTOR_IR_BTOR_TYPES_H
+#define BTOR_IR_BTOR_TYPES_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+//===----------------------------------------------------------------------===//
+// Btor Dialect Types
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "Dialect/Btor/IR/BtorOpsTypes.h.inc"
+
+using namespace mlir;
+using namespace mlir::btor;
+
+#endif // BTOR_IR_BTOR_TYPES_H

--- a/include/Dialect/Btor/IR/BtorTypes.td
+++ b/include/Dialect/Btor/IR/BtorTypes.td
@@ -1,0 +1,24 @@
+#ifndef BTOR_TYPES
+#define BTOR_TYPES
+
+include "BtorBase.td"
+
+class Btor_BaseType<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<Btor_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def Btor_BitVec : Btor_BaseType<"BitVec", "bv"> {
+  let summary = "bit vector behaving similar to unsinged int";
+  let description = [{
+    Bit vectors have designated length.
+  }];
+
+  let parameters = (ins "unsigned":$length);
+
+  let assemblyFormat = "`<` $length `>`";
+
+  let genVerifyDecl = 0;
+}
+
+#endif // BTOR_TYPES

--- a/include/Dialect/Btor/IR/CMakeLists.txt
+++ b/include/Dialect/Btor/IR/CMakeLists.txt
@@ -1,6 +1,12 @@
 set(LLVM_TARGET_DEFINITIONS BtorOps.td)
-mlir_tablegen(BtorOpsEnums.h.inc -gen-enum-decls)
-mlir_tablegen(BtorOpsEnums.cpp.inc -gen-enum-defs)
 add_mlir_dialect(BtorOps btor)
 
+set(LLVM_TARGET_DEFINITIONS BtorAttributes.td)
+mlir_tablegen(BtorAttributes.h.inc -gen-attrdef-decls)
+mlir_tablegen(BtorAttributes.cpp.inc -gen-attrdef-defs)
+mlir_tablegen(BtorOpsEnums.h.inc -gen-enum-decls)
+mlir_tablegen(BtorOpsEnums.cpp.inc -gen-enum-defs)
+add_public_tablegen_target(BtorAttributesIncGen)
+
+add_mlir_doc(BtorAttributes BtorAttributes Dialects/ -gen-attrdef-doc)
 add_mlir_doc(BtorOps BtorOps Dialects/ -gen-op-doc)

--- a/lib/Dialect/Btor/CMakeLists.txt
+++ b/lib/Dialect/Btor/CMakeLists.txt
@@ -2,12 +2,14 @@ add_mlir_dialect_library(MLIRBtor
         IR/BtorDialect.cpp
         IR/BtorOps.cpp
         IR/BtorTypes.cpp
+        IR/BtorAttributes.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/Dialect/Btor
 
         DEPENDS
         MLIRBtorOpsIncGen
+        BtorAttributesIncGen
 
 	LINK_LIBS PUBLIC
     MLIRDialect

--- a/lib/Dialect/Btor/CMakeLists.txt
+++ b/lib/Dialect/Btor/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRBtor
         IR/BtorDialect.cpp
         IR/BtorOps.cpp
+        IR/BtorTypes.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/Dialect/Btor

--- a/lib/Dialect/Btor/IR/BtorAttributes.cpp
+++ b/lib/Dialect/Btor/IR/BtorAttributes.cpp
@@ -1,0 +1,74 @@
+//===- BtorTypes.cpp - Btor dialect ---------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/Btor/IR/Btor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "Dialect/Btor/IR/BtorTypes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "Dialect/Btor/IR/BtorAttributes.h"
+
+using namespace mlir;
+using namespace mlir::btor;
+
+void BitVecAttr::print(::mlir::AsmPrinter &printer) const {
+  printer << "<";
+  printer << this->getType();
+  printer << ' ' << "=";
+  printer << ' ';
+  printer.printStrippedAttrOrType(this->getValue());
+  printer << ">";
+}
+
+::mlir::Attribute BitVecAttr::parse(::mlir::AsmParser &parser,
+                                    ::mlir::Type type) {
+  ::mlir::FailureOr<BitVecType> _result_type;
+  ::mlir::FailureOr<unsigned> _result_value;
+  ::llvm::SMLoc loc = parser.getCurrentLocation();
+  (void)loc;
+  // Parse literal '<'
+  if (parser.parseLess())
+    return {};
+
+  // Parse variable 'type'
+  _result_type = ::mlir::FieldParser<BitVecType>::parse(parser);
+  if (failed(_result_type)) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "failed to parse BitVecAttribute parameter 'type' which "
+                     "is to be a `BitVecType`");
+    return {};
+  }
+  // Parse literal '='
+  if (parser.parseEqual())
+    return {};
+
+  // Parse variable 'value'
+  _result_value = ::mlir::FieldParser<unsigned>::parse(parser);
+  if (failed(_result_value)) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "failed to parse BitVecAttribute parameter 'value' which "
+                     "is to be a `APInt`");
+    return {};
+  }
+  // Parse literal '>'
+  if (parser.parseGreater())
+    return {};
+  return BitVecAttr::get(
+      parser.getContext(), _result_type.getValue(),
+      APInt(_result_type.getValue().getLength(), _result_value.getValue()));
+}
+
+#define GET_ATTRDEF_CLASSES
+#include "Dialect/Btor/IR/BtorAttributes.cpp.inc"
+
+void BtorDialect::registerAttrs() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "Dialect/Btor/IR/BtorAttributes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/Btor/IR/BtorDialect.cpp
+++ b/lib/Dialect/Btor/IR/BtorDialect.cpp
@@ -20,6 +20,7 @@ using namespace mlir::btor;
 
 void BtorDialect::initialize() {
   registerTypes();
+  registerAttrs();
   addOperations<
 #define GET_OP_LIST
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"

--- a/lib/Dialect/Btor/IR/BtorDialect.cpp
+++ b/lib/Dialect/Btor/IR/BtorDialect.cpp
@@ -19,6 +19,7 @@ using namespace mlir::btor;
 //===----------------------------------------------------------------------===//
 
 void BtorDialect::initialize() {
+  registerTypes();
   addOperations<
 #define GET_OP_LIST
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"

--- a/lib/Dialect/Btor/IR/BtorTypes.cpp
+++ b/lib/Dialect/Btor/IR/BtorTypes.cpp
@@ -1,0 +1,26 @@
+//===- BtorTypes.cpp - Btor dialect ---------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/Btor/IR/BtorTypes.h"
+#include "Dialect/Btor/IR/Btor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::btor;
+
+#define GET_TYPEDEF_CLASSES
+#include "Dialect/Btor/IR/BtorOpsTypes.cpp.inc"
+
+void BtorDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "Dialect/Btor/IR/BtorOpsTypes.cpp.inc"
+      >();
+}


### PR DESCRIPTION
Cherry-picked commits from https://github.com/jetafese/btor2mlir/pull/12 that only have the declaration and definition of custom types and attributes.
This PR does not include changing any operation definitions or any conversion passes. It does not break or modify any features. It only defines the custom types and attributes but do not use them or have them included anywhere in the functional code.