### PR TITLE
feat: support detection of violated property for witness generation

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -838,9 +838,9 @@ def AssertNotOp : Btor_Op<"assert_not"> {
         ```
     }];
 
-    let arguments = (ins I1:$arg);
+    let arguments = (ins I1:$arg, AnyI64Attr:$id);
 
-    let assemblyFormat = "`(` $arg `)` attr-dict";
+    let assemblyFormat = "`(` $arg `)` attr-dict `,` $id";
 }
 
 def ConstantOp : Btor_Op<"constant", [ConstantLike, NoSideEffect,


### PR DESCRIPTION
Given a btor2 circuit below, we propagate the property number through to llvm-ir

```
1 sort bitvec 8
2 input 1
3 sort bitvec 1
4 zero 3
5 state 3
6 init 3 5 4
7 redand 3 2
8 next 3 5 7
9 bad 5
10 bad 7
```

The two properties are then captured as assertion 0 and 1 below:
```
module {
  func @main() {
    %0 = btor.constant false
    br ^bb1(%0 : i1)
  ^bb1(%1: i1):  // 2 preds: ^bb0, ^bb1
    %2 = btor.input 0 : i8
    %3 = btor.redand %2 : i8
    btor.assert_not(%1), 0 : i64
    btor.assert_not(%3), 1 : i64
    br ^bb1(%3 : i1)
  }
}
```
And finally, we reveal the propery numbers using an external function `__VERIFIER_assert`:

```
declare void @__VERIFIER_error()
declare void @__VERIFIER_assert(i1, i64)
declare void @btor2mlir_print_input_num(i64, i64, i64)
declare i8 @nd_bv8_in0()
define void @main() !dbg !3 {
  br label %1, !dbg !7
1:                                                ; preds = %10, %0
  %2 = phi i1 [ %6, %10 ], [ false, %0 ]
  %3 = call i8 @nd_bv8_in0(), !dbg !9
  %4 = zext i8 %3 to i64, !dbg !10
  call void @btor2mlir_print_input_num(i64 0, i64 %4, i64 8), !dbg !11
  %5 = bitcast i8 %3 to <8 x i1>, !dbg !12
  %6 = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %5), !dbg !13
  %7 = xor i1 %2, true, !dbg !14
  br i1 %7, label %8, label %11, !dbg !15
8:                                                ; preds = %1
  %9 = xor i1 %6, true, !dbg !16
  br i1 %9, label %10, label %12, !dbg !17
10:                                               ; preds = %8
  br label %1, !dbg !18
11:                                               ; preds = %1
  call void @__VERIFIER_assert(i1 %7, i64 0), !dbg !19
  call void @__VERIFIER_error(), !dbg !20
  unreachable, !dbg !21

12:                                               ; preds = %8
  call void @__VERIFIER_assert(i1 %9, i64 1), !dbg !22
  call void @__VERIFIER_error(), !dbg !23
  unreachable, !dbg !24
}
```