### PR TITLE
For BtorIRToBtor, use array type for serialization

### DIFF
--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -150,12 +150,10 @@ class Deserialize {
   // Builder wrappers
   Type getTypeOf(const Btor2Line *line) {
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
-      // unsigned indexWidth = pow(2, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
       auto shape = btor::BitVecType::get(m_context, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
       auto elementType = btor::BitVecType::get(m_context,
         m_sorts.at(line->sort.array.element)->sort.bitvec.width);
       return btor::ArrayType::get(m_context, shape, elementType);
-      // return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
       ;
     }
     return btor::BitVecType::get(m_context, line->sort.bitvec.width);

--- a/lib/Target/Btor/BtorIRToBtorTranslation.cpp
+++ b/lib/Target/Btor/BtorIRToBtorTranslation.cpp
@@ -96,12 +96,11 @@ void Serialize::createSort(Type type) {
     setSortWithType(type, nextLine);
     m_output << nextLine << " sort bitvec " << bitWidth << '\n';
   } else {
-    assert (type.isa<VectorType>());
-    auto shape = type.cast<VectorType>().getShape().front();
-    auto elementType = type.cast<VectorType>().getElementType();
-    Type shapeType = IntegerType::get(type.getContext(), unsigned (log2(shape)));
-    assert (elementType.getIntOrFloatBitWidth() > 0);
-    assert (shapeType.getIntOrFloatBitWidth() > 0);
+    assert (type.isa<btor::ArrayType>());
+    auto shapeType = type.cast<btor::ArrayType>().getShape();
+    auto elementType = type.cast<btor::ArrayType>().getElement();
+    assert (elementType.getWidth() > 0);
+    assert (shapeType.getWidth() > 0);
 
     auto shapeSort = getOrCreateSort(shapeType);
     auto elementSort = getOrCreateSort(elementType);


### PR DESCRIPTION
- Cleaned some commented codes
- For Btor IR to Btor translation, use the new array type to replace the vector type.