### PR TITLE
feat: array operations with custom types

### DIFF
--- a/include/Conversion/BtorToLLVM/ConvertBtorToLLVMPass.h
+++ b/include/Conversion/BtorToLLVM/ConvertBtorToLLVMPass.h
@@ -4,9 +4,9 @@
 #include <memory>
 #include <utility>
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "Dialect/Btor/IR/Btor.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 namespace mlir {
 class BtorToLLVMTypeConverter;
@@ -14,43 +14,44 @@ class RewritePatternSet;
 class Pass;
 
 namespace btor {
-    
-    /// Collect a set of patterns to lower from btor to LLVM dialect
-    void populateBtorToLLVMConversionPatterns(BtorToLLVMTypeConverter &converter,
-                                                RewritePatternSet &patterns);
 
-    /// Creates a pass to convert the Btor dialect into the LLVM dialect.
-    std::unique_ptr<mlir::Pass> createLowerToLLVMPass();
+/// Collect a set of patterns to lower from btor to LLVM dialect
+void populateBtorToLLVMConversionPatterns(BtorToLLVMTypeConverter &converter,
+                                          RewritePatternSet &patterns);
+
+/// Creates a pass to convert the Btor dialect into the LLVM dialect.
+std::unique_ptr<mlir::Pass> createLowerToLLVMPass();
 
 } // namespace btor
-    class BtorToLLVMTypeConverter : public LLVMTypeConverter {
+class BtorToLLVMTypeConverter : public LLVMTypeConverter {
 public:
-        BtorToLLVMTypeConverter(MLIRContext *ctx,
-                                    const DataLayoutAnalysis *analysis = nullptr)
-            : LLVMTypeConverter(ctx, analysis) {
-            addConversion([&](btor::BitVecType type) -> llvm::Optional<Type> {
-                return convertBtorBitVecType(type);
-            });
-            addConversion([&](btor::ArrayType type) -> llvm::Optional<Type> {
-                return convertBtorArrayType(type);
-            });
-        }
+  BtorToLLVMTypeConverter(MLIRContext *ctx,
+                          const DataLayoutAnalysis *analysis = nullptr)
+      : LLVMTypeConverter(ctx, analysis) {
+    addConversion([&](btor::BitVecType type) -> llvm::Optional<Type> {
+      return convertBtorBitVecType(type);
+    });
+    addConversion([&](btor::ArrayType type) -> llvm::Optional<Type> {
+      return convertBtorArrayType(type);
+    });
+  }
 
-        Type convertBtorBitVecType(btor::BitVecType type) {
-            return ::IntegerType::get(type.getContext(), type.getWidth());
-        }
+  Type convertBtorBitVecType(btor::BitVecType type) {
+    return ::IntegerType::get(type.getContext(), type.getWidth());
+  }
 
-        Type convertIntegerType(mlir::IntegerType type) {
-            return btor::BitVecType::get(type.getContext(), type.getWidth());
-        }
+  Type convertIntegerType(mlir::IntegerType type) {
+    return btor::BitVecType::get(type.getContext(), type.getWidth());
+  }
 
-        VectorType convertBtorArrayType(btor::ArrayType type) {
-            unsigned indexWidth = pow(2, type.getShape().getWidth());
-            auto elementType =  ::IntegerType::get(type.getContext(), type.getElement().getWidth());
-            // return MemRefType::get(ArrayRef<int64_t>{indexWidth}, elementType);
-            return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
-        }
-    };
+  VectorType convertBtorArrayType(btor::ArrayType type) {
+    unsigned indexWidth = pow(2, type.getShape().getWidth());
+    auto elementType =
+        ::IntegerType::get(type.getContext(), type.getElement().getWidth());
+    // return MemRefType::get(ArrayRef<int64_t>{indexWidth}, elementType);
+    return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
+  }
+};
 
 } // namespace mlir
 

--- a/include/Conversion/BtorToLLVM/ConvertBtorToLLVMPass.h
+++ b/include/Conversion/BtorToLLVM/ConvertBtorToLLVMPass.h
@@ -2,6 +2,7 @@
 #define BTOR_CONVERSION_BTORTOLLVM_CONVERTBTORTOLLVMPASS_H_
 
 #include <memory>
+#include <utility>
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
@@ -30,6 +31,9 @@ public:
             addConversion([&](btor::BitVecType type) -> llvm::Optional<Type> {
                 return convertBtorBitVecType(type);
             });
+            addConversion([&](btor::ArrayType type) -> llvm::Optional<Type> {
+                return convertBtorArrayType(type);
+            });
         }
 
         Type convertBtorBitVecType(btor::BitVecType type) {
@@ -40,7 +44,12 @@ public:
             return btor::BitVecType::get(type.getContext(), type.getWidth());
         }
 
-
+        VectorType convertBtorArrayType(btor::ArrayType type) {
+            unsigned indexWidth = pow(2, type.getShape().getWidth());
+            auto elementType =  ::IntegerType::get(type.getContext(), type.getElement().getWidth());
+            // return MemRefType::get(ArrayRef<int64_t>{indexWidth}, elementType);
+            return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
+        }
     };
 
 } // namespace mlir

--- a/include/Conversion/BtorToVector/ConvertBtorToVectorPass.h
+++ b/include/Conversion/BtorToVector/ConvertBtorToVectorPass.h
@@ -1,6 +1,7 @@
 #ifndef BTOR_CONVERSION_BTORTOVECTOR_CONVERTBTORTOVECTORPASS_H_
 #define BTOR_CONVERSION_BTORTOVECTOR_CONVERTBTORTOVECTORPASS_H_
 
+#include "Conversion/BtorToLLVM/ConvertBtorToLLVMPass.h"
 #include <memory>
 
 namespace mlir {
@@ -9,11 +10,12 @@ class Pass;
 class RewritePatternSet;
 
 namespace btor {
-    /// Collect a set of patterns to lower from btor to vector dialect
-    void populateBtorToVectorConversionPatterns(RewritePatternSet &patterns);
+/// Collect a set of patterns to lower from btor to vector dialect
+void populateBtorToVectorConversionPatterns(BtorToLLVMTypeConverter &converter,
+                                            RewritePatternSet &patterns);
 
-    /// Creates a pass to convert the Btor dialect into the vector dialect.
-    std::unique_ptr<Pass> createLowerToVectorPass();
+/// Creates a pass to convert the Btor dialect into the vector dialect.
+std::unique_ptr<Pass> createLowerToVectorPass();
 
 } // namespace btor
 } // namespace mlir

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -975,6 +975,39 @@ def VectorInitArrayOp : Btor_Op<"array_vec"> {
     return printVectorInitArrayOp(p, *this);
   }];
 }
+
+def VectorReadOp : Btor_Op<"read_vec"> {
+  let summary = "btor read operation using vector types";
+  let description = [{
+    The `read` op reads an element from a btor array specified by an index. 
+    The output of load is a new value with the same type as the elements of the
+    btor array.
+
+    Example:
+
+    ```mlir
+    %1 = btor.read %A[%0] : vector<8xi32>, i32
+    ```
+  }];
+
+  let arguments = (ins AnyVector:$base, SignlessIntegerLike:$index);
+  let results = (outs SignlessIntegerLike:$result);
+
+  let extraClassDeclaration = [{
+    VectorType getArrayType() {
+      return base().getType().cast<VectorType>();
+    }
+  }];
+
+  let verifier = [{ return verifyVectorReadOp(*this); }];
+  let parser = [{
+    return parseVectorReadOp(parser, result);
+  }];
+  let printer = [{
+    return printVectorReadOp(p, *this);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Btor arrays
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -941,6 +941,41 @@ def InputOp : Btor_Op<"input"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Vector using Btor arrays
+//===----------------------------------------------------------------------===//
+
+def VectorInitArrayOp : Btor_Op<"array_vec"> {
+  let summary = "btor initialized array allocation operation using vector types";
+  let description = [{
+    The `array` operation represents a btor array, using vectors,
+     that has been initialized with a value. 
+
+    For example:
+
+    ```mlir
+    %4 = btor.array_vec %1 : vector<8xi32>
+    ```
+
+    This operation returns a single SSA value of a vector type used
+    by subsequent read and write operations. 
+  }];
+
+  let arguments = (ins SignlessIntegerLike:$init);
+  let results = (outs AnyVector:$result);
+  let extraClassDeclaration = [{
+    VectorType getArrayType() {
+      return result().getType().cast<VectorType>();
+    }
+  }];
+  let verifier = [{ return verifyVectorInitArrayOp(*this); }];
+  let parser = [{
+    return parseVectorInitArrayOp(parser, result);
+  }];
+  let printer = [{
+    return printVectorInitArrayOp(p, *this);
+  }];
+}
+//===----------------------------------------------------------------------===//
 // Btor arrays
 //===----------------------------------------------------------------------===//
 

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -951,19 +951,19 @@ def ArrayOp : Btor_Op<"nd_array"> {
     bitvec -> bitvec. For example:
 
     ```mlir
-    %0 = btor.nd_array : vector<8,!bv<32>>
+    %0 = btor.nd_array : !array<!bv<8>,!bv<32>>
     ```
 
     This operation returns a single SSA value of a btor array type used
     by subsequent read and write operations. 
   }];
 
-  let results = (outs AnyVector:$result);
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let results = (outs Btor_Array:$result);
+  let assemblyFormat = "attr-dict `:` qualified(type($result))";
   let verifier = [{ return verifyArrayOp(*this); }];
   let extraClassDeclaration = [{
-    VectorType getArrayType() {
-      return result().getType().cast<VectorType>();
+    ArrayType getArrayType() {
+      return result().getType().cast<ArrayType>();
     }
   }];
 }
@@ -977,7 +977,7 @@ def InitArrayOp : Btor_Op<"array"> {
     For example:
 
     ```mlir
-    %4 = btor.array %1 : vector<8,!bv<32>>
+    %4 = btor.array %1 : !array<!bv<8>,!bv<32>>
     ```
 
     This operation returns a single SSA value of a btor array type used
@@ -985,10 +985,10 @@ def InitArrayOp : Btor_Op<"array"> {
   }];
 
   let arguments = (ins Btor_BitVec:$init);
-  let results = (outs AnyVector:$result);
+  let results = (outs Btor_Array:$result);
   let extraClassDeclaration = [{
-    VectorType getArrayType() {
-      return result().getType().cast<VectorType>();
+    ArrayType getArrayType() {
+      return result().getType().cast<ArrayType>();
     }
   }];
   let verifier = [{ return verifyInitArrayOp(*this); }];
@@ -1010,16 +1010,16 @@ def ReadOp : Btor_Op<"read"> {
     Example:
 
     ```mlir
-    %1 = btor.read %A[%0] : vector<8,!bv<32>>, !bv<32>
+    %1 = btor.read %A[%0] : !array<!bv<8>,!bv<32>>, !bv<32>
     ```
   }];
 
-  let arguments = (ins AnyVector:$base, Btor_BitVec:$index);
+  let arguments = (ins Btor_Array:$base, Btor_BitVec:$index);
   let results = (outs Btor_BitVec:$result);
 
   let extraClassDeclaration = [{
-    VectorType getArrayType() {
-      return base().getType().cast<VectorType>();
+    ArrayType getArrayType() {
+      return base().getType().cast<ArrayType>();
     }
   }];
 
@@ -1041,17 +1041,17 @@ def WriteOp : Btor_Op<"write"> {
     Example:
 
     ```mlir
-    %4 = btor.write %2, %A[%1] : vector<8, !bv<32>>
+    %4 = btor.write %2, %A[%1] : !array<!bv<8>,!bv<32>>
     ```
   }];
 
-  let arguments = (ins Btor_BitVec:$value, AnyVector:$base,
+  let arguments = (ins Btor_BitVec:$value, Btor_Array:$base,
                        Btor_BitVec:$index);
 
-  let results = (outs AnyVector:$result);
+  let results = (outs Btor_Array:$result);
     let extraClassDeclaration = [{
-    VectorType getArrayType() {
-      return base().getType().cast<VectorType>();
+    ArrayType getArrayType() {
+      return base().getType().cast<ArrayType>();
     }
   }];
 

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -1008,6 +1008,38 @@ def VectorReadOp : Btor_Op<"read_vec"> {
   }];
 }
 
+def VectorWriteOp : Btor_Op<"write_vec"> {
+  let summary = "btor write operation with vector types";
+  let description = [{
+    Copy the given array and write the given value to the provided
+    location given by index. The value stored should have the same type 
+    as the elemental type of the array. 
+    Example:
+
+    ```mlir
+    %4 = btor.write %2, %A[%1] : vector<8xi32>
+    ```
+  }];
+
+  let arguments = (ins SignlessIntegerLike:$value, AnyVector:$base,
+                       SignlessIntegerLike:$index);
+
+  let results = (outs AnyVector:$result);
+    let extraClassDeclaration = [{
+    VectorType getArrayType() {
+      return base().getType().cast<VectorType>();
+    }
+  }];
+
+  let verifier = [{ return verifyVectorWriteOp(*this); }];
+  let parser = [{
+    return parseVectorWriteOp(parser, result);
+  }];
+  let printer = [{
+    return printVectorWriteOp(p, *this);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Btor arrays
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -19,52 +19,48 @@ include "mlir/IR/BuiltinAttributes.td"
 include "Dialect/Btor/IR/BtorTypes.td"
 include "Dialect/Btor/IR/BtorAttributes.td"
 
-
 //===----------------------------------------------------------------------===//
 // Base btor operation definition.
 //===----------------------------------------------------------------------===//
 
-class Btor_Op<string mnemonic, list<Trait> traits = []> :
-        Op<Btor_Dialect, mnemonic, traits>;
-
+class Btor_Op<string mnemonic, list<Trait> traits = []>
+    : Op<Btor_Dialect, mnemonic, traits>;
 
 //===----------------------------------------------------------------------===//
 // btor integer bit cast ops definitions
 //===----------------------------------------------------------------------===//
 
-// Base class for Btor Cast operations Requires a single operand and result. 
+// Base class for Btor Cast operations Requires a single operand and result.
 class Btor_CastOp<string mnemonic, TypeConstraint From, TypeConstraint To,
-                   list<Trait> traits = []> :
-    Btor_Op<mnemonic, traits # [SameOperandsAndResultShape]>,
-    Arguments<(ins From:$in)>,
-    Results<(outs To:$out)> {
+                  list<Trait> traits = []>
+    : Btor_Op<mnemonic, traits #[SameOperandsAndResultShape]>,
+      Arguments<(ins From
+                 : $in)>,
+      Results<(outs To
+               : $out)> {
   let assemblyFormat = "$in attr-dict `:` type($in) `to` type($out)";
 }
 
 // Cast from an integer type to another integer type.
-class BtorCastOp<string mnemonic> :
-    Btor_CastOp<mnemonic, Btor_BitVec, Btor_BitVec> {
-  let builders = [
-    OpBuilder<(ins "Value":$in, "Type":$type),
-     [{
-        build($_builder, $_state, type, in);
-      }]>
-    ];
+class BtorCastOp<string mnemonic>
+    : Btor_CastOp<mnemonic, Btor_BitVec, Btor_BitVec> {
+  let builders = [OpBuilder<(ins "Value"
+                             : $in, "Type"
+                             : $type),
+                            [{ build($_builder, $_state, type, in); }]>];
 }
-
 
 def UExtOp : BtorCastOp<"uext"> {
   let summary = "integer zero extension operation";
   let description = [{
-    The integer zero extension operation takes an integer input of
-    width M and an integer destination type of width N. The destination
-    bit-width must be larger than the input bit-width (N > M).
-    The top-most (N - M) bits of the output are filled with zeros.
+    The integer zero extension operation takes an integer input of width M and
+        an integer destination type of width N.The destination bit -
+    width must be larger than the input bit - width(N > M).The top -
+    most(N - M) bits of the output are filled with zeros.
 
     Example:
 
-    ```mlir
-      %2 = btor.uext %1 : !bv<3> to !bv<9>
+    ```mlir % 2 = btor.uext % 1: !bv<3> to !bv<9>
     ```
   }];
   let verifier = [{ return verifyExtOp<btor::BitVecType>(*this); }];
@@ -73,16 +69,15 @@ def UExtOp : BtorCastOp<"uext"> {
 def SExtOp : BtorCastOp<"sext"> {
   let summary = "integer zero extension operation";
   let description = [{
-    The integer zero extension operation takes an integer input of
-    width M and an integer destination type of width N. The destination
-    bit-width must be larger than the input bit-width (N > M).
-    The top-most (N - M) bits of the output are filled with
-    copies of the most-significant bit of the input.
+    The integer zero extension operation takes an integer input of width M and
+        an integer destination type of width N.The destination bit -
+    width must be larger than the input bit - width(N > M).The top -
+    most(N - M) bits of the output are filled with copies of the most -
+    significant bit of the input.
 
     Example:
 
-    ```mlir
-      %2 = btor.sext %1 : !bv<3> to !bv<9>
+    ```mlir % 2 = btor.sext % 1: !bv<3> to !bv<9>
     ```
   }];
   let verifier = [{ return verifyExtOp<btor::BitVecType>(*this); }];
@@ -92,403 +87,430 @@ def SExtOp : BtorCastOp<"sext"> {
 // btor ternary integer ops definitions
 //===----------------------------------------------------------------------===//
 
-def IteOp : Btor_Op<"ite", [NoSideEffect,
-    AllTypesMatch<["true_value", "false_value", "result"]>]
-    #ElementwiseMappable.traits> {
-    
+def IteOp : Btor_Op < "ite",
+    [NoSideEffect, AllTypesMatch<["true_value", "false_value", "result"]>]
+#ElementwiseMappable.traits> {
+
     let summary = "integer if-then-else operation";
-    let description = [{
-        This operation takes a condition and two integer 
-        arguments and returns an integer.
+let description = [{
+  This operation takes a condition and two integer arguments and returns an
+      integer.
 
-        Example:
+  Example:
         
-        ```mlir
-        %res = btor.ite %cond, %true, %false : !bv<32>
+        ```mlir % res = btor.ite % cond,
+  % true,
+  %
+  false: !bv<32>
         ```
-    }];
+}];
 
-  let arguments = (ins Btor_BitVec:$condition,
-                      AnyType:$true_value,
-                      AnyType:$false_value);
-  let results = (outs AnyType:$result);
-  
+let arguments = (ins Btor_BitVec
+                 : $condition, AnyType
+                 : $true_value, AnyType
+                 : $false_value);
+let results = (outs AnyType : $result);
+
   let extraClassDeclaration = [{
-    Value getCondition() { return condition(); }
-    Value getTrueValue() { return true_value(); }
-    Value getFalseValue() { return false_value(); }
+    Value getCondition() { return condition();
+  }
+  Value getTrueValue() { return true_value(); }
+  Value getFalseValue() { return false_value(); }
   }];
 
-  let parser = [{
-    return parseIteOp(parser, result);
-  }];
+  let parser = [{ return parseIteOp(parser, result); }];
 
-  let printer = [{
-    return printIteOp(p, this);
-  }];
-}
+  let printer = [{ return printIteOp(p, this); }];
+  }
 
-def SliceOp : Btor_Op<"slice", [NoSideEffect,
-    AllTypesMatch<["upper_bound", "lower_bound"]>]
-    #ElementwiseMappable.traits> {
-    
-    let summary = "integer slice operation";
-    let description = [{
-        This operation takes an input of size N and two integer 
-        arguments, U and L, and returns an integer of size:
-                U - L + 1, where L <= U < N.
+  def SliceOp : Btor_Op < "slice",
+      [NoSideEffect, AllTypesMatch<["upper_bound", "lower_bound"]>]
+#ElementwiseMappable.traits> {
 
-        Example:
+      let summary = "integer slice operation";
+  let description = [{
+    This operation takes an input of size N and two integer arguments,
+    U and L,
+    and returns an integer of size: U - L + 1,
+    where L <= U < N.
+
+    Example:
         
-        ```mlir
-        %res = btor.slice %in, %upper, %lower : iN, i(upper-lower+1)
+        ```mlir % res = btor.slice % in,
+    % upper,
+    %
+    lower: iN, i(upper - lower + 1)
         ```
-    }];
-
-  let arguments = (ins Btor_BitVec:$in,
-                      Btor_BitVec:$upper_bound,
-                      Btor_BitVec:$lower_bound);
-  let results = (outs Btor_BitVec:$result);
-
-  let builders = [
-    OpBuilder<(ins "Value":$in, 
-                   "Value":$upper_bound, 
-                   "Value":$lower_bound),
-     [{
-       $_state.addOperands({in, upper_bound, lower_bound});
-      }]>
-    ];
-
-  let parser = [{
-    return parseSliceOp(parser, result);
   }];
-  
-  let printer = [{
-    return printSliceOp(p, this->getOperation());
-  }];
+
+  let arguments = (ins Btor_BitVec
+                   : $in, Btor_BitVec
+                   : $upper_bound, Btor_BitVec
+                   : $lower_bound);
+  let results = (outs Btor_BitVec : $result);
+
+  let builders =
+      [OpBuilder<(ins "Value"
+                  : $in, "Value"
+                  : $upper_bound, "Value"
+                  : $lower_bound),
+                 [{
+                   $_state.addOperands({in, upper_bound, lower_bound});
+                 }]>];
+
+  let parser = [{ return parseSliceOp(parser, result); }];
+
+  let printer = [{ return printSliceOp(p, this->getOperation()); }];
 
   let verifier = [{ return verifySliceOp<btor::BitVecType>(*this); }];
-}
+  }
 
-//===----------------------------------------------------------------------===//
-// btor binary integer ops definitions
-//===----------------------------------------------------------------------===//
+  //===----------------------------------------------------------------------===//
+  // btor binary integer ops definitions
+  //===----------------------------------------------------------------------===//
 
-// Base class for btor arithmetic operations.  Requires operands and
-// results to be of the same type, but does not constrain them to specific
-// types.
-class BtorArithmeticOp<string mnemonic, list<Trait> traits = []> :
-    Op<Btor_Dialect, mnemonic, traits>;
+  // Base class for btor arithmetic operations.  Requires operands and
+  // results to be of the same type, but does not constrain them to specific
+  // types.
+  class BtorArithmeticOp<string mnemonic, list<Trait> traits = []>
+      : Op<Btor_Dialect, mnemonic, traits>;
 
-// This operation takes two operands and returns one result,
-// each of these is required to be of the same type.
-//  The custom assembly form of the operation is as follows
-//
-//     <op> %0, %1 : !bv<32>
-class BtorBinaryOp<string mnemonic, list<Trait> traits = []> :
-    BtorArithmeticOp<mnemonic, !listconcat(traits, [SameOperandsAndResultType])>,
-    Arguments<(ins Btor_BitVec:$lhs, Btor_BitVec:$rhs)>,
-    Results<(outs Btor_BitVec:$result)> {
-        let assemblyFormat = "$lhs `,` $rhs attr-dict `:` qualified(type($result))";
-    }
+  // This operation takes two operands and returns one result,
+  // each of these is required to be of the same type.
+  //  The custom assembly form of the operation is as follows
+  //
+  //     <op> %0, %1 : !bv<32>
+  class BtorBinaryOp<string mnemonic, list<Trait> traits = []>
+      : BtorArithmeticOp<mnemonic,
+                         !listconcat(traits, [SameOperandsAndResultType])>,
+        Arguments<(ins Btor_BitVec
+                   : $lhs, Btor_BitVec
+                   : $rhs)>,
+        Results<(outs Btor_BitVec
+                 : $result)> {
+    let assemblyFormat = "$lhs `,` $rhs attr-dict `:` qualified(type($result))";
+  }
 
-// This operation takes two operands or the same type
-// and returns one result of type !bv<1>
-//
-//     <op> %0, %1 : !bv<1>
-class BtorBinaryDifferentResultTypeOp<string mnemonic, list<Trait> traits = []> :
-    BtorArithmeticOp<mnemonic, traits>,
-    Arguments<(ins Btor_BitVec:$lhs, Btor_BitVec:$rhs)> {
+  // This operation takes two operands or the same type
+  // and returns one result of type !bv<1>
+  //
+  //     <op> %0, %1 : !bv<1>
+  class BtorBinaryDifferentResultTypeOp<string mnemonic,
+                                        list<Trait> traits = []>
+      : BtorArithmeticOp<mnemonic, traits>,
+        Arguments<(ins Btor_BitVec
+                   : $lhs, Btor_BitVec
+                   : $rhs)> {
 
-  let results = (outs Btor_BitVec:$result);
-  
-  let parser = [{
-    return parseBinaryOverflowOp(parser, result);
-  }];
+    let results = (outs Btor_BitVec : $result);
 
-  let printer = [{
-    return printBinaryOverflowOp(p, this->getOperation());
-  }];
-}
+    let parser = [{ return parseBinaryOverflowOp(parser, result); }];
 
-def AddOp : BtorBinaryOp<"add", [Commutative]> {
+    let printer = [{ return printBinaryOverflowOp(p, this->getOperation()); }];
+  }
+
+  def AddOp : BtorBinaryOp<"add", [Commutative]> {
     let summary = "integer addition operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.add %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.add % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def SAddOverflowOp : BtorBinaryDifferentResultTypeOp<"saddo", [Commutative]> {
+  def SAddOverflowOp : BtorBinaryDifferentResultTypeOp<"saddo", [Commutative]> {
     let summary = "signed integer addition with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.saddo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.saddo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def UAddOverflowOp : BtorBinaryDifferentResultTypeOp<"uaddo", [Commutative]> {
+  def UAddOverflowOp : BtorBinaryDifferentResultTypeOp<"uaddo", [Commutative]> {
     let summary = "unsigned integer addition with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.uaddo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.uaddo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def SubOp : BtorBinaryOp<"sub"> {
+  def SubOp : BtorBinaryOp<"sub"> {
     let summary = "integer subtraction operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.sub %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.sub % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def SSubOverflowOp : BtorBinaryDifferentResultTypeOp<"ssubo"> {
+  def SSubOverflowOp : BtorBinaryDifferentResultTypeOp<"ssubo"> {
     let summary = "signed integer subtraction with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.ssubo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.ssubo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def USubOverflowOp : BtorBinaryDifferentResultTypeOp<"usubo"> {
+  def USubOverflowOp : BtorBinaryDifferentResultTypeOp<"usubo"> {
     let summary = "unsigned integer subtraction with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.usubo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.usubo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def MulOp : BtorBinaryOp<"mul", [Commutative]> {
+  def MulOp : BtorBinaryOp<"mul", [Commutative]> {
     let summary = "integer multiplication operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.mul %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.mul % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def SMulOverflowOp : BtorBinaryDifferentResultTypeOp<"smulo"> {
+  def SMulOverflowOp : BtorBinaryDifferentResultTypeOp<"smulo"> {
     let summary = "signed integer multiplication with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.smulo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.smulo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def UMulOverflowOp : BtorBinaryDifferentResultTypeOp<"umulo"> {
+  def UMulOverflowOp : BtorBinaryDifferentResultTypeOp<"umulo"> {
     let summary = "unsigned integer multiplication with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.umulo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.umulo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def SModOp : BtorBinaryOp<"smod"> {
+  def SModOp : BtorBinaryOp<"smod"> {
     let summary = "integer signed modulus operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.smod %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.smod % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def SRemOp : BtorBinaryOp<"srem"> {
+  def SRemOp : BtorBinaryOp<"srem"> {
     let summary = "integer signed remainder operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.srem %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.srem % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def URemOp : BtorBinaryOp<"urem"> {
+  def URemOp : BtorBinaryOp<"urem"> {
     let summary = "integer unsigned remainder operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.urem %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.urem % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def SDivOp : BtorBinaryOp<"sdiv"> {
+  def SDivOp : BtorBinaryOp<"sdiv"> {
     let summary = "integer signed division operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.sdiv %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.sdiv % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def SDivOverflowOp : BtorBinaryDifferentResultTypeOp<"sdivo"> {
+  def SDivOverflowOp : BtorBinaryDifferentResultTypeOp<"sdivo"> {
     let summary = "signed integer division with overflow flag";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.sdivo %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.sdivo % lhs,
+      %
+      rhs: !bv<1>
         ```
-    }];  
-}
+    }];
+  }
 
-def UDivOp : BtorBinaryOp<"udiv"> {
+  def UDivOp : BtorBinaryOp<"udiv"> {
     let summary = "integer unsigned division operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.udiv %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.udiv % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def OrOp : BtorBinaryOp<"or", [Commutative]> {
+  def OrOp : BtorBinaryOp<"or", [Commutative]> {
     let summary = "integer binary and operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.or %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.or % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def NorOp : BtorBinaryOp<"nor", [Commutative]> {
+  def NorOp : BtorBinaryOp<"nor", [Commutative]> {
     let summary = "integer binary nor operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.nor %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.nor % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def AndOp : BtorBinaryOp<"and", [Commutative]> {
+  def AndOp : BtorBinaryOp<"and", [Commutative]> {
     let summary = "integer binary and operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.and %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.and % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def NandOp : BtorBinaryOp<"nand", [Commutative]> {
+  def NandOp : BtorBinaryOp<"nand", [Commutative]> {
     let summary = "integer binary nand operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.nand %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.nand % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def XOrOp : BtorBinaryOp<"xor", [Commutative]> {
+  def XOrOp : BtorBinaryOp<"xor", [Commutative]> {
     let summary = "integer binary xor operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.xor %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.xor % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def XnorOp : BtorBinaryOp<"xnor", [Commutative]> {
+  def XnorOp : BtorBinaryOp<"xnor", [Commutative]> {
     let summary = "integer binary xnor operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.xnor %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.xnor % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
-     TypesMatchWith<"result type has !bv<1> element type and same shape as operands",
-    "lhs", "result", "getI1SameShape($_self)">] # ElementwiseMappable.traits> {
-  let summary = "integer comparison operation";
-  let description = [{
+  def CmpOp : Btor_Op<"cmp", [
+    NoSideEffect, SameTypeOperands,
+    TypesMatchWith<
+        "result type has !bv<1> element type and same shape as operands", "lhs",
+        "result", "getI1SameShape($_self)">
+  ] #ElementwiseMappable.traits> {
+    let summary = "integer comparison operation";
+    let description = [{
     The `cmp` operation is a generic comparison for two arguments 
     that need to have their types matching.
 
@@ -514,262 +536,273 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
     // Custom form of scalar "signed less than" comparison.
     %x = btor.cmp "slt", %lhs, %rhs : !bv<1>
     ```
-  }];
+    }];
 
-  let arguments = (ins
-      BtorPredicateAttr:$predicate,
-      Btor_BitVec:$lhs,
-      Btor_BitVec:$rhs
-  );
-  let results = (outs Btor_BitVec:$result);
+    let arguments = (ins BtorPredicateAttr
+                     : $predicate, Btor_BitVec
+                     : $lhs, Btor_BitVec
+                     : $rhs);
+    let results = (outs Btor_BitVec : $result);
 
-  let builders = [
-    OpBuilder<(ins "BtorPredicate":$predicate, "Value":$lhs,
-                 "Value":$rhs), [{
-      build($_builder, $_state, ::getI1SameShape(lhs.getType()),
-            predicate, lhs, rhs);
-    }]>];
+    let builders =
+        [OpBuilder<(ins "BtorPredicate"
+                    : $predicate, "Value"
+                    : $lhs, "Value"
+                    : $rhs),
+                   [{
+                     build($_builder, $_state, ::getI1SameShape(lhs.getType()),
+                           predicate, lhs, rhs);
+                   }]>];
 
-  
-  let extraClassDeclaration = [{
-    static StringRef getPredicateAttrName() { return "predicate"; }
-    static BtorPredicate getPredicateByName(StringRef name);
+    let extraClassDeclaration = [{
+      static StringRef getPredicateAttrName() { return "predicate"; }
+      static BtorPredicate getPredicateByName(StringRef name);
 
-    BtorPredicate getPredicate() {
-      return (BtorPredicate)(*this)->getAttrOfType<IntegerAttr>(
-          getPredicateAttrName()).getInt();
-    }
-  }];
+      BtorPredicate getPredicate() {
+        return (BtorPredicate)(*this)
+            ->getAttrOfType<IntegerAttr>(getPredicateAttrName())
+            .getInt();
+      }
+    }];
 
-  let verifier = [{ return verifyCmpOp(*this); }];
+    let verifier = [{ return verifyCmpOp(*this); }];
 
-  let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` qualified(type($lhs))";
-} 
+    let assemblyFormat =
+        "$predicate `,` $lhs `,` $rhs attr-dict `:` qualified(type($lhs))";
+  }
 
-def IffOp : BtorBinaryOp<"iff"> {
+  def IffOp : BtorBinaryOp<"iff"> {
     let summary = "integer if-and-only-if operation";
     let description = [{
-        This operation takes two !bv<1> arguments and returns a !bv<1>.
+      This operation takes two !bv<1> arguments and returns a !bv<1>.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.iff %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.iff % lhs,
+      %
+      rhs: !bv<1>
         ```
     }];
 
     let verifier = [{ return verifyBooleanOp(*this); }];
-}
+  }
 
-def ImpliesOp : BtorBinaryOp<"implies"> {
+  def ImpliesOp : BtorBinaryOp<"implies"> {
     let summary = "integer implication operation";
     let description = [{
-        This operation takes two !bv<1> arguments and returns a !bv<1>.
+      This operation takes two !bv<1> arguments and returns a !bv<1>.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.implies %lhs, %rhs : !bv<1>
+        ```mlir % res = btor.implies % lhs,
+      %
+      rhs: !bv<1>
         ```
     }];
-    
-    let verifier = [{ return verifyBooleanOp(*this); }];
-}
 
-def ShiftLLOp : BtorBinaryOp<"sll"> {
+    let verifier = [{ return verifyBooleanOp(*this); }];
+  }
+
+  def ShiftLLOp : BtorBinaryOp<"sll"> {
     let summary = "integer left logical shift binary operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.sll %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.sll % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def ShiftRLOp : BtorBinaryOp<"srl"> {
+  def ShiftRLOp : BtorBinaryOp<"srl"> {
     let summary = "integer right logical shift operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.srl %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.srl % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def ShiftRAOp : BtorBinaryOp<"sra"> {
+  def ShiftRAOp : BtorBinaryOp<"sra"> {
     let summary = "integer right arithmetic shift operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.sra %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.sra % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def RotateLOp : BtorBinaryOp<"rol"> {
+  def RotateLOp : BtorBinaryOp<"rol"> {
     let summary = "integer left rotate operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.rol %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.rol % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def RotateROp : BtorBinaryOp<"ror"> {
+  def RotateROp : BtorBinaryOp<"ror"> {
     let summary = "integer right rotate operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer.
+      This operation takes two integer arguments and returns an integer.
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.ror %lhs, %rhs : !bv<32>
+        ```mlir % res = btor.ror % lhs,
+      %
+      rhs: !bv<32>
         ```
     }];
-}
+  }
 
-def ConcatOp : Btor_Op<"concat"> {
+  def ConcatOp : Btor_Op<"concat"> {
     let summary = "integer concatenation operation";
     let description = [{
-        This operation takes two integer arguments of length N and M
-        and returns an integer of length N+M
+      This operation takes two integer arguments of length N and M and returns
+              an integer of length N +
+          M
 
-        Example:
+      Example:
         
-        ```mlir
-        %res = btor.concat %lhs, %rhs : !bv<3>, !bv<2>, !bv<5>
+        ```mlir % res = btor.concat % lhs,
+      %
+      rhs: !bv<3>, !bv<2>, !bv<5>
         ```
-    }];  
-
-    let arguments = (ins Btor_BitVec:$lhs, Btor_BitVec:$rhs);
-    let results = (outs Btor_BitVec:$result);
-
-    let parser = [{
-      return parseConcatOp(parser, result);
     }];
-    let printer = [{
-      return printConcatOp(p, *this);
-    }];
+
+    let arguments = (ins Btor_BitVec : $lhs, Btor_BitVec : $rhs);
+    let results = (outs Btor_BitVec : $result);
+
+    let parser = [{ return parseConcatOp(parser, result); }];
+    let printer = [{ return printConcatOp(p, *this); }];
     let verifier = [{ return verifyConcatOp<btor::BitVecType>(*this); }];
-}
+  }
 
-//===----------------------------------------------------------------------===//
-// btor unary integer ops definitions
-//===----------------------------------------------------------------------===//
+  //===----------------------------------------------------------------------===//
+  // btor unary integer ops definitions
+  //===----------------------------------------------------------------------===//
 
-// Base class for unary ops. Requires single operand and result. Individual
-// classes will have `operand` accessor.
-class BtorUnaryOp<string mnemonic, list<Trait> traits = []> :
-    Op<Btor_Dialect, mnemonic, !listconcat(traits, [NoSideEffect,
-        SameOperandsAndResultType])>,
-    Arguments<(ins Btor_BitVec:$operand)>,
-    Results<(outs Btor_BitVec:$result)> {
-    
+  // Base class for unary ops. Requires single operand and result. Individual
+  // classes will have `operand` accessor.
+  class BtorUnaryOp<string mnemonic, list<Trait> traits = []>
+      : Op<Btor_Dialect, mnemonic,
+           !listconcat(traits, [NoSideEffect, SameOperandsAndResultType])>,
+        Arguments<(ins Btor_BitVec
+                   : $operand)>,
+        Results<(outs Btor_BitVec
+                 : $result)> {
+
     let assemblyFormat = "$operand attr-dict `:` qualified(type($result))";
-}
+  }
 
-// This operation takes an operand
-// and returns one result of type bv<1>
-//
-//     <op> %0 : !bv<1>
-class BtorUnaryDifferentResultTypeOp<string mnemonic, list<Trait> traits = []> :
-    Op<Btor_Dialect, mnemonic, !listconcat(traits, [NoSideEffect])>,
-    Arguments<(ins Btor_BitVec:$operand)> {
+  // This operation takes an operand
+  // and returns one result of type bv<1>
+  //
+  //     <op> %0 : !bv<1>
+  class BtorUnaryDifferentResultTypeOp<string mnemonic, list<Trait> traits = []>
+      : Op<Btor_Dialect, mnemonic, !listconcat(traits, [NoSideEffect])>,
+        Arguments<(ins Btor_BitVec
+                   : $operand)> {
 
-  let results = (outs Btor_BitVec:$result);
-   let parser = [{
-    return parseUnaryDifferentResultOp(parser, result);
-  }];
+    let results = (outs Btor_BitVec : $result);
+    let parser = [{ return parseUnaryDifferentResultOp(parser, result); }];
 
-  let printer = [{
-    return printBtorUnaryOp(p, this->getOperation());
-  }];
-}
+    let printer = [{ return printBtorUnaryOp(p, this->getOperation()); }];
+  }
 
-def NotOp : BtorUnaryOp<"not"> {
-  let summary = "integer negation";
-  let description = [{
-    Syntax:
+  def NotOp : BtorUnaryOp<"not"> {
+    let summary = "integer negation";
+    let description = [{
+      Syntax:
 
-    The `not` operation computes the negation of a given value. It takes one
-    operand and returns one result of the same type. 
+          The `not` operation computes the negation of a given value
+              .It takes one operand and returns one result of the same type.
 
-    Example:
+      Example:
 
     ```mlir
-    // Scalar negation value.
-    %a = btor.not %b : !bv<32>
+          // Scalar negation value.
+          % a = btor.not %
+      b: !bv<32>
     ```
-  }];
-}
+    }];
+  }
 
-def IncOp : BtorUnaryOp<"inc"> {
-  let summary = "integer increment by one";
-  let description = [{
-    Syntax:
+  def IncOp : BtorUnaryOp<"inc"> {
+    let summary = "integer increment by one";
+    let description = [{
+      Syntax:
 
-    The `inc` operation increments the given value by one. It takes one
-    operand and returns one result of the same type. 
+          The `inc` operation increments the given value by
+              one.It takes one operand and returns one result of the same type.
 
-    Example:
+      Example:
 
     ```mlir
-    // Scalar increment value.
-    %a = btor.inc %b : !bv<32>
+          // Scalar increment value.
+          % a = btor.inc %
+      b: !bv<32>
     ```
-  }];
-}
+    }];
+  }
 
-def DecOp : BtorUnaryOp<"dec"> {
-  let summary = "integer decrement by one";
-  let description = [{
-    Syntax:
+  def DecOp : BtorUnaryOp<"dec"> {
+    let summary = "integer decrement by one";
+    let description = [{
+      Syntax:
 
-    The `dec` operation decrements the given value by one. It takes one
-    operand and returns one result of the same type. 
+          The `dec` operation decrements the given value by
+              one.It takes one operand and returns one result of the same type.
 
-    Example:
+      Example:
 
     ```mlir
-    // Scalar decrement value.
-    %a = btor.dec %b : !bv<32>
+          // Scalar decrement value.
+          % a = btor.dec %
+      b: !bv<32>
     ```
-  }];
-}
+    }];
+  }
 
-def NegOp : BtorUnaryOp<"neg"> {
-  let summary = "integer negation";
-  let description = [{
-    Syntax:
+  def NegOp : BtorUnaryOp<"neg"> {
+    let summary = "integer negation";
+    let description = [{
+      Syntax:
 
-    The `neg` operation flips the sign of a given value. It takes one
-    operand and returns one result of the same type. 
+          The `neg` operation flips the sign of a given value
+              .It takes one operand and returns one result of the same type.
 
-    Example:
+      Example:
 
     ```mlir
-    // Scalar decrement value.
-    %a = btor.neg %b : !bv<32>
+          // Scalar decrement value.
+          % a = btor.neg %
+      b: !bv<32>
     ```
-  }];
-}
+    }];
+  }
 
-def RedAndOp : BtorUnaryDifferentResultTypeOp<"redand"> {
-  let summary = "integer reduction with and operator";
-  let description = [{
+  def RedAndOp : BtorUnaryDifferentResultTypeOp<"redand"> {
+    let summary = "integer reduction with and operator";
+    let description = [{
     Syntax:
 
     The `redand` operation computes the and reduction of a given value. It takes one
@@ -782,11 +815,11 @@ def RedAndOp : BtorUnaryDifferentResultTypeOp<"redand"> {
     %a = btor.redand %b : !bv<1>
     ```
   }];
-}
+  }
 
-def RedOrOp : BtorUnaryDifferentResultTypeOp<"redor"> {
-  let summary = "integer reduction with or operator";
-  let description = [{
+  def RedOrOp : BtorUnaryDifferentResultTypeOp<"redor"> {
+    let summary = "integer reduction with or operator";
+    let description = [{
     Syntax:
 
     This operation computes the or reduction of a given value. It takes one
@@ -799,11 +832,11 @@ def RedOrOp : BtorUnaryDifferentResultTypeOp<"redor"> {
     %a = btor.redand %b : !bv<1>
     ```
   }];
-}
+  }
 
-def RedXorOp : BtorUnaryDifferentResultTypeOp<"redxor"> {
-  let summary = "integer reduction with and operator";
-  let description = [{
+  def RedXorOp : BtorUnaryDifferentResultTypeOp<"redxor"> {
+    let summary = "integer reduction with and operator";
+    let description = [{
     Syntax:
 
     This operation computes the xor reduction of a given value. It takes one
@@ -816,53 +849,53 @@ def RedXorOp : BtorUnaryDifferentResultTypeOp<"redxor"> {
     %a = btor.redand %b : !bv<1>
     ```
   }];
-}
+  }
 
-def AssertNotOp : Btor_Op<"assert_not"> {
+  def AssertNotOp : Btor_Op<"assert_not"> {
     let summary = "btor assertion to mimic bad operation";
     let description = [{
-        This operation takes one boolean argument and terminates
-        the program if the argument is false.
+      This operation takes one boolean argument and terminates the
+              program if the argument is false.
 
-        Example:
+          Example :
         
-        ```mlir
-        %0 = constant 1 : !bv<1>
-        // Apply the assert operation to %0
-        btor.assert_not ( %0 )
+        ```mlir %
+          0 = constant 1 : !bv<1>
+                               // Apply the assert operation to %0
+                               btor.assert_not(% 0)
         ```
     }];
 
-    let arguments = (ins Btor_BitVec:$arg, AnyI64Attr:$id);
+    let arguments = (ins Btor_BitVec : $arg, AnyI64Attr : $id);
 
     let assemblyFormat = "`(` $arg `)` attr-dict `,` $id qualified(type($arg))";
-}
+  }
 
-def ConstantOp : Btor_Op<"constant", [ConstantLike, NoSideEffect]> {
-  let summary = "integer constant";
-  let description = [{
-    The `constant` operation produces an SSA value equal to some constant
-    specified by an attribute. 
+  def ConstantOp : Btor_Op<"constant", [ConstantLike, NoSideEffect]> {
+    let summary = "integer constant";
+    let description = [{
+      The `constant` operation produces an SSA value equal to some constant
+          specified by an attribute.
 
-    Example:
+      Example:
 
     ```mlir
-    // Integer constant
-    %1 = constant 42 : !bv<32>
+          // Integer constant
+          % 1 = constant 42: !bv<32>
     ```
-  }];
+    }];
 
-  let arguments = (ins Builtin_IntegerAttr:$value);
-  let results = (outs Btor_BitVec:$result);
+    let arguments = (ins Builtin_IntegerAttr : $value);
+    let results = (outs Btor_BitVec : $result);
 
-  let assemblyFormat = "attr-dict $value qualified(type($result))";
+    let assemblyFormat = "attr-dict $value qualified(type($result))";
 
-  let verifier = [{ return verifyConstantOp(*this); }];
-  
-  let hasFolder = 1;
-}
+    let verifier = [{ return verifyConstantOp(*this); }];
 
-def ConstraintOp : Btor_Op<"constraint"> {
+    let hasFolder = 1;
+  }
+
+  def ConstraintOp : Btor_Op<"constraint"> {
     let summary = "btor constraint";
     let description = [{
         This operation takes one boolean argument and assumes 
@@ -877,176 +910,160 @@ def ConstraintOp : Btor_Op<"constraint"> {
         ```
     }];
 
-    let arguments = (ins Btor_BitVec:$constraint);
+    let arguments = (ins Btor_BitVec : $constraint);
 
-    let assemblyFormat = "`(` $constraint `)` attr-dict `:` qualified(type($constraint))";
+    let assemblyFormat =
+        "`(` $constraint `)` attr-dict `:` qualified(type($constraint))";
 
     let verifier = [{ return verifyConstraintOp(*this); }];
-}
+  }
 
-def NDStateOp : Btor_Op<"nd_state"> {
+  def NDStateOp : Btor_Op<"nd_state"> {
     let summary = "btor nondet bv state";
     let description = [{
-        This operation takes no input and returns
-        a BitVecType
+      This operation takes no input and returns a BitVecType
 
-        Example:
+      Example:
 
         ```mlir
-        // invoke the nd_bv operation 
-        %0 = btor.nd_state 15 : !bv<32>
-        ```
-        In the example above, 15 gets interpreted as an
-        i64 integer to represent the 15th input of a circuit
+             // invoke the nd_bv operation
+             % 0 = btor.nd_state 15: !bv<32>
+        ``` In the example above,
+      15 gets interpreted as an i64 integer to represent the 15th input of a
+          circuit
     }];
 
-    let arguments = (ins AnyI64Attr:$id);
-    let results = (outs Btor_BitVec:$result);
-    let parser = [{
-      return parseNDStateOpOp(parser, result);
-    }];
+    let arguments = (ins AnyI64Attr : $id);
+    let results = (outs Btor_BitVec : $result);
+    let parser = [{ return parseNDStateOpOp(parser, result); }];
 
-    let printer = [{
-      return printNDStateOpOp(p, *this);
-    }];    
-}
+    let printer = [{ return printNDStateOpOp(p, *this); }];
+  }
 
-def InputOp : Btor_Op<"input"> {
+  def InputOp : Btor_Op<"input"> {
     let summary = "btor input";
     let description = [{
-        This operation takes an input number and then returns a
-        BitVec Type value
+      This operation takes an input number and then returns a BitVec Type value
 
-        Example:
+      Example:
 
         ```mlir
-        // invoke the input operation to %0
-        %0 = btor.input 15 : !bv<32>
+             // invoke the input operation to %0
+             % 0 = btor.input 15: !bv<32>
         ```
 
-        In the example above, 15 gets interpreted as an
-        i64 integer to represent the line number of the input
+                   In the example above,
+      15 gets interpreted as an i64 integer to represent the line number of the
+          input
     }];
 
-    let arguments = (ins AnyI64Attr:$id);
-    let results = (outs Btor_BitVec:$result);
+    let arguments = (ins AnyI64Attr : $id);
+    let results = (outs Btor_BitVec : $result);
 
-    let parser = [{
-      return parseInputOp(parser, result);
-    }];
+    let parser = [{ return parseInputOp(parser, result); }];
 
-    let printer = [{
-      return printInputOp(p, *this);
-    }];
-}
+    let printer = [{ return printInputOp(p, *this); }];
+  }
 
-//===----------------------------------------------------------------------===//
-// Vector using Btor arrays
-//===----------------------------------------------------------------------===//
+  //===----------------------------------------------------------------------===//
+  // Vector using Btor arrays
+  //===----------------------------------------------------------------------===//
 
-def VectorInitArrayOp : Btor_Op<"array_vec"> {
-  let summary = "btor initialized array allocation operation using vector types";
-  let description = [{
-    The `array` operation represents a btor array, using vectors,
-     that has been initialized with a value. 
+  def VectorInitArrayOp : Btor_Op<"array_vec"> {
+    let summary =
+        "btor initialized array allocation operation using vector types";
+    let description = [{
+      The `array` operation represents a btor array,
+      using vectors,
+      that has been initialized with a value.
 
-    For example:
+      For example:
 
-    ```mlir
-    %4 = btor.array_vec %1 : vector<8xi32>
+    ```mlir % 4 = btor.array_vec %
+                   1: vector<8xi32>
     ```
 
-    This operation returns a single SSA value of a vector type used
-    by subsequent read and write operations. 
-  }];
+                   This operation returns a single SSA value of a vector type
+                       used by subsequent read and write operations.
+    }];
 
-  let arguments = (ins SignlessIntegerLike:$init);
-  let results = (outs AnyVector:$result);
+    let arguments = (ins SignlessIntegerLike : $init);
+    let results = (outs AnyVector : $result);
   let extraClassDeclaration = [{
     VectorType getArrayType() {
       return result().getType().cast<VectorType>();
-    }
+  }
   }];
   let verifier = [{ return verifyVectorInitArrayOp(*this); }];
-  let parser = [{
-    return parseVectorInitArrayOp(parser, result);
-  }];
-  let printer = [{
-    return printVectorInitArrayOp(p, *this);
-  }];
-}
+  let parser = [{ return parseVectorInitArrayOp(parser, result); }];
+  let printer = [{ return printVectorInitArrayOp(p, *this); }];
+  }
 
-def VectorReadOp : Btor_Op<"read_vec"> {
-  let summary = "btor read operation using vector types";
-  let description = [{
-    The `read` op reads an element from a btor array specified by an index. 
-    The output of load is a new value with the same type as the elements of the
-    btor array.
+  def VectorReadOp : Btor_Op<"read_vec"> {
+    let summary = "btor read operation using vector types";
+    let description = [{
+      The `read` op reads an element from a btor array specified by an index
+          .The output of load is a new value with the same type as the elements
+              of the btor array.
 
-    Example:
+      Example:
 
-    ```mlir
-    %1 = btor.read %A[%0] : vector<8xi32>, i32
+    ```mlir % 1 = btor.read % A[% 0]: vector<8xi32>,
+      i32
     ```
-  }];
+    }];
 
-  let arguments = (ins AnyVector:$base, SignlessIntegerLike:$index);
-  let results = (outs SignlessIntegerLike:$result);
+    let arguments = (ins AnyVector : $base, SignlessIntegerLike : $index);
+    let results = (outs SignlessIntegerLike : $result);
 
   let extraClassDeclaration = [{
     VectorType getArrayType() {
       return base().getType().cast<VectorType>();
-    }
+  }
   }];
 
   let verifier = [{ return verifyVectorReadOp(*this); }];
-  let parser = [{
-    return parseVectorReadOp(parser, result);
-  }];
-  let printer = [{
-    return printVectorReadOp(p, *this);
-  }];
-}
+  let parser = [{ return parseVectorReadOp(parser, result); }];
+  let printer = [{ return printVectorReadOp(p, *this); }];
+  }
 
-def VectorWriteOp : Btor_Op<"write_vec"> {
-  let summary = "btor write operation with vector types";
-  let description = [{
-    Copy the given array and write the given value to the provided
-    location given by index. The value stored should have the same type 
-    as the elemental type of the array. 
-    Example:
+  def VectorWriteOp : Btor_Op<"write_vec"> {
+    let summary = "btor write operation with vector types";
+    let description = [{
+      Copy the given array and write the given value to the provided location
+          given by index
+              .The value stored should have the same type as the elemental type
+                  of the array.Example:
 
-    ```mlir
-    %4 = btor.write %2, %A[%1] : vector<8xi32>
+    ```mlir % 4 = btor.write % 2,
+      % A[% 1]: vector<8xi32>
     ```
-  }];
+    }];
 
-  let arguments = (ins SignlessIntegerLike:$value, AnyVector:$base,
-                       SignlessIntegerLike:$index);
+    let arguments = (ins SignlessIntegerLike
+                     : $value, AnyVector
+                     : $base, SignlessIntegerLike
+                     : $index);
 
-  let results = (outs AnyVector:$result);
+    let results = (outs AnyVector : $result);
     let extraClassDeclaration = [{
     VectorType getArrayType() {
       return base().getType().cast<VectorType>();
-    }
+  }
   }];
 
   let verifier = [{ return verifyVectorWriteOp(*this); }];
-  let parser = [{
-    return parseVectorWriteOp(parser, result);
-  }];
-  let printer = [{
-    return printVectorWriteOp(p, *this);
-  }];
-}
+  let parser = [{ return parseVectorWriteOp(parser, result); }];
+  let printer = [{ return printVectorWriteOp(p, *this); }];
+  }
 
-//===----------------------------------------------------------------------===//
-// Btor arrays
-//===----------------------------------------------------------------------===//
+  //===----------------------------------------------------------------------===//
+  // Btor arrays
+  //===----------------------------------------------------------------------===//
 
-def ArrayOp : Btor_Op<"nd_array"> {
-  let summary = "btor array allocation operation";
-  let description = [{
+  def ArrayOp : Btor_Op<"nd_array"> {
+    let summary = "btor array allocation operation";
+    let description = [{
     The `nd_array` operation represents a btor array from 
     bitvec -> bitvec. For example:
 
@@ -1058,110 +1075,100 @@ def ArrayOp : Btor_Op<"nd_array"> {
     by subsequent read and write operations. 
   }];
 
-  let results = (outs Btor_Array:$result);
-  let assemblyFormat = "attr-dict `:` qualified(type($result))";
-  let verifier = [{ return verifyArrayOp(*this); }];
+    let results = (outs Btor_Array : $result);
+    let assemblyFormat = "attr-dict `:` qualified(type($result))";
+    let verifier = [{ return verifyArrayOp(*this); }];
   let extraClassDeclaration = [{
     ArrayType getArrayType() {
       return result().getType().cast<ArrayType>();
-    }
+  }
   }];
-}
+  }
 
-def InitArrayOp : Btor_Op<"array"> {
-  let summary = "btor initialized array allocation operation";
-  let description = [{
-    The `array` operation represents a btor array from 
-    bitvec -> bitvec that has been initialized with a value. 
+  def InitArrayOp : Btor_Op<"array"> {
+    let summary = "btor initialized array allocation operation";
+    let description = [{
+      The `array` operation represents a btor array from
+          bitvec->bitvec that has been initialized with a value.
 
-    For example:
+      For example:
 
-    ```mlir
-    %4 = btor.array %1 : !array<!bv<8>,!bv<32>>
+    ```mlir % 4 = btor.array %
+                   1: !array<!bv<8>, !bv<32>>
     ```
 
-    This operation returns a single SSA value of a btor array type used
-    by subsequent read and write operations. 
-  }];
+                   This operation returns a single SSA value of a btor array
+                       type used by subsequent read and write operations.
+    }];
 
-  let arguments = (ins Btor_BitVec:$init);
-  let results = (outs Btor_Array:$result);
+    let arguments = (ins Btor_BitVec : $init);
+    let results = (outs Btor_Array : $result);
   let extraClassDeclaration = [{
     ArrayType getArrayType() {
       return result().getType().cast<ArrayType>();
-    }
+  }
   }];
   let verifier = [{ return verifyInitArrayOp(*this); }];
-  let parser = [{
-    return parseInitArrayOp(parser, result);
-  }];
-  let printer = [{
-    return printInitArrayOp(p, *this);
-  }];
-}
+  let parser = [{ return parseInitArrayOp(parser, result); }];
+  let printer = [{ return printInitArrayOp(p, *this); }];
+  }
 
-def ReadOp : Btor_Op<"read"> {
-  let summary = "btor read operation";
-  let description = [{
-    The `read` op reads an element from a btor array specified by an index. 
-    The output of load is a new value with the same type as the elements of the
-    btor array.
+  def ReadOp : Btor_Op<"read"> {
+    let summary = "btor read operation";
+    let description = [{
+      The `read` op reads an element from a btor array specified by an index
+          .The output of load is a new value with the same type as the elements
+              of the btor array.
 
-    Example:
+      Example:
 
-    ```mlir
-    %1 = btor.read %A[%0] : !array<!bv<8>,!bv<32>>, !bv<32>
+    ```mlir % 1 = btor.read % A[% 0]: !array<!bv<8>, !bv<32>>,
+      !bv<32>
     ```
-  }];
+    }];
 
-  let arguments = (ins Btor_Array:$base, Btor_BitVec:$index);
-  let results = (outs Btor_BitVec:$result);
+    let arguments = (ins Btor_Array : $base, Btor_BitVec : $index);
+    let results = (outs Btor_BitVec : $result);
 
   let extraClassDeclaration = [{
     ArrayType getArrayType() {
       return base().getType().cast<ArrayType>();
-    }
+  }
   }];
 
   let verifier = [{ return verifyReadOp(*this); }];
-  let parser = [{
-    return parseReadOp(parser, result);
-  }];
-  let printer = [{
-    return printReadOp(p, *this);
-  }];
-}
+  let parser = [{ return parseReadOp(parser, result); }];
+  let printer = [{ return printReadOp(p, *this); }];
+  }
 
-def WriteOp : Btor_Op<"write"> {
-  let summary = "btor write operation";
-  let description = [{
-    Copy the given array and write the given value to the provided
-    location given by index. The value stored should have the same type 
-    as the elemental type of the array. 
-    Example:
+  def WriteOp : Btor_Op<"write"> {
+    let summary = "btor write operation";
+    let description = [{
+      Copy the given array and write the given value to the provided location
+          given by index
+              .The value stored should have the same type as the elemental type
+                  of the array.Example:
 
-    ```mlir
-    %4 = btor.write %2, %A[%1] : !array<!bv<8>,!bv<32>>
+    ```mlir % 4 = btor.write % 2,
+      % A[% 1]: !array<!bv<8>, !bv<32>>
     ```
-  }];
+    }];
 
-  let arguments = (ins Btor_BitVec:$value, Btor_Array:$base,
-                       Btor_BitVec:$index);
+    let arguments = (ins Btor_BitVec
+                     : $value, Btor_Array
+                     : $base, Btor_BitVec
+                     : $index);
 
-  let results = (outs Btor_Array:$result);
+    let results = (outs Btor_Array : $result);
     let extraClassDeclaration = [{
     ArrayType getArrayType() {
       return base().getType().cast<ArrayType>();
-    }
+  }
   }];
 
   let verifier = [{ return verifyWriteOp(*this); }];
-  let parser = [{
-    return parseWriteOp(parser, result);
-  }];
-  let printer = [{
-    return printWriteOp(p, *this);
-  }];
-}
+  let parser = [{ return parseWriteOp(parser, result); }];
+  let printer = [{ return printWriteOp(p, *this); }];
+  }
 
 #endif // BTOR_OPS

--- a/include/Dialect/Btor/IR/BtorTypes.td
+++ b/include/Dialect/Btor/IR/BtorTypes.td
@@ -21,4 +21,16 @@ def Btor_BitVec : Btor_BaseType<"BitVec", "bv"> {
   let genVerifyDecl = 0;
 }
 
+def Btor_Array : Btor_BaseType<"Array", "array"> {
+  let summary = "btor array";
+  let description = [{
+    A Btor array parametrized by two btor bit vectors
+  }];
+
+  let parameters = (ins "BitVecType":$shape, "BitVecType":$element);
+
+  let assemblyFormat = "`<` $shape `,` $element `>`";
+
+  let genVerifyDecl = 0;
+}
 #endif // BTOR_TYPES

--- a/include/Dialect/Btor/IR/BtorTypes.td
+++ b/include/Dialect/Btor/IR/BtorTypes.td
@@ -10,11 +10,9 @@ class Btor_BaseType<string name, string typeMnemonic, list<Trait> traits = []>
 
 def Btor_BitVec : Btor_BaseType<"BitVec", "bv"> {
   let summary = "bit vector behaving similar to unsinged int";
-  let description = [{
-    Bit vectors have designated width.
-  }];
+  let description = [{Bit vectors have designated width.}];
 
-  let parameters = (ins "unsigned":$width);
+  let parameters = (ins "unsigned" : $width);
 
   let assemblyFormat = "`<` $width `>`";
 
@@ -23,11 +21,9 @@ def Btor_BitVec : Btor_BaseType<"BitVec", "bv"> {
 
 def Btor_Array : Btor_BaseType<"Array", "array"> {
   let summary = "btor array";
-  let description = [{
-    A Btor array parametrized by two btor bit vectors
-  }];
+  let description = [{A Btor array parametrized by two btor bit vectors}];
 
-  let parameters = (ins "BitVecType":$shape, "BitVecType":$element);
+  let parameters = (ins "BitVecType" : $shape, "BitVecType" : $element);
 
   let assemblyFormat = "`<` $shape `,` $element `>`";
 

--- a/include/Target/Btor/BtorIRToBtorTranslation.h
+++ b/include/Target/Btor/BtorIRToBtorTranslation.h
@@ -9,15 +9,15 @@
 
 #include "Dialect/Btor/IR/Btor.h"
 
-#include "mlir/IR/OwningOpRef.h"
-#include "mlir/Support/LLVM.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/Support/LLVM.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 #include "btor2parser/btor2parser.h"
 
@@ -32,26 +32,26 @@ namespace btor {
 
 class Serialize {
 
- public:
-///===----------------------------------------------------------------------===//
-/// Constructors and Destructors
-///===----------------------------------------------------------------------===//
+public:
+  ///===----------------------------------------------------------------------===//
+  /// Constructors and Destructors
+  ///===----------------------------------------------------------------------===//
 
-  Serialize(ModuleOp module, raw_ostream &output) : m_module(module),
-    m_output(output)  {}
+  Serialize(ModuleOp module, raw_ostream &output)
+      : m_module(module), m_output(output) {}
 
   ~Serialize() {}
 
   LogicalResult translateMainFunction();
 
   uint64_t getSort(const Type type) {
-    assert (sortIsInCache(type));
+    assert(sortIsInCache(type));
     ::llvm::hash_code code = hash_value(type);
     return m_sorts.at(code);
   }
 
   void setSortWithType(const Type type, const uint64_t id) {
-    assert (!sortIsInCache(type));
+    assert(!sortIsInCache(type));
     ::llvm::hash_code code = hash_value(type);
     m_sorts[code] = id;
     assert(sortIsInCache(type));
@@ -63,23 +63,24 @@ class Serialize {
   }
 
   uint64_t getOpFromCache(const Value &value) {
-    assert (opIsInCache(value));
+    assert(opIsInCache(value));
     ::llvm::hash_code code = hash_value(value);
     return m_cache.at(code);
   }
 
   void setCacheWithOp(const Value &value, const uint64_t id) {
-    assert (!opIsInCache(value));
+    assert(!opIsInCache(value));
     ::llvm::hash_code code = hash_value(value);
     m_cache[code] = id;
-    assert (opIsInCache(value));
+    assert(opIsInCache(value));
   }
 
   bool opIsInCache(const Value &value) {
     ::llvm::hash_code code = hash_value(value);
     return m_cache.count(code) != 0;
   }
- private:
+
+private:
   ModuleOp m_module;
   raw_ostream &m_output;
   uint64_t nextLine = 1;
@@ -95,7 +96,7 @@ class Serialize {
   LogicalResult translateInitFunction(mlir::Block &initBlock);
   LogicalResult translateNextFunction(mlir::Block &nextBlock);
   LogicalResult createBtor(mlir::Operation &op, bool isInit);
-  
+
   LogicalResult createBtorLine(btor::ConstantOp &op, bool isInit);
   LogicalResult createBtorLine(btor::InputOp &op, bool isInit);
   LogicalResult createBtorLine(btor::RedAndOp &op, bool isInit);
@@ -150,13 +151,15 @@ class Serialize {
   LogicalResult createBtorLine(mlir::BranchOp &op, bool isInit);
 
   LogicalResult buildTernaryOperation(const Value &first, const Value &second,
-                const Value &third, const Value &res, Type type, std::string op);
+                                      const Value &third, const Value &res,
+                                      Type type, std::string op);
   LogicalResult buildBinaryOperation(const Value &lhs, const Value &rhs,
-                const Value &res, Type type, std::string op);
+                                     const Value &res, Type type,
+                                     std::string op);
   LogicalResult buildUnaryOperation(const Value &lhs, const Value &res,
-                Type type, std::string op);
-  LogicalResult buildCastOperation(const Value &in, const Value &res, 
-                Type type, std::string op);
+                                    Type type, std::string op);
+  LogicalResult buildCastOperation(const Value &in, const Value &res, Type type,
+                                   std::string op);
 };
 
 /// Register the Btor translation

--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -150,12 +150,10 @@ class Deserialize {
   // Builder wrappers
   Type getTypeOf(const Btor2Line *line) {
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
-      // unsigned indexWidth = pow(2, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
       auto shape = btor::BitVecType::get(m_context, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
       auto elementType = btor::BitVecType::get(m_context,
         m_sorts.at(line->sort.array.element)->sort.bitvec.width);
       return btor::ArrayType::get(m_context, shape, elementType);
-      // return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
       ;
     }
     return btor::BitVecType::get(m_context, line->sort.bitvec.width);

--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -8,19 +8,19 @@
 #define TARGET_BTOR_BTORTOBTORIRTRANSLATION_H
 
 #include "Dialect/Btor/IR/Btor.h"
-#include "Dialect/Btor/IR/BtorTypes.h"
 #include "Dialect/Btor/IR/BtorAttributes.h"
+#include "Dialect/Btor/IR/BtorTypes.h"
 
-#include "mlir/IR/OwningOpRef.h"
-#include "mlir/Support/LLVM.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/Support/LLVM.h"
 
-#include <vector>
 #include <map>
 #include <utility>
+#include <vector>
 
 #include "btor2parser/btor2parser.h"
 
@@ -35,36 +35,37 @@ namespace btor {
 
 class Deserialize {
 
- public:
-///===----------------------------------------------------------------------===//
-/// Constructors and Destructors
-///===----------------------------------------------------------------------===//
+public:
+  ///===----------------------------------------------------------------------===//
+  /// Constructors and Destructors
+  ///===----------------------------------------------------------------------===//
 
-  Deserialize(MLIRContext *context, const std::string &s) : m_context(context), 
-    m_builder(OpBuilder(m_context)), m_unknownLoc(UnknownLoc::get(m_context)) {
-        m_modelFile = fopen(s.c_str(), "r");
-        m_sourceFile = m_builder.getStringAttr(s);
-    }
-
-  ~Deserialize() {
-      if (m_model) {
-        btor2parser_delete(m_model);
-      }
-      if (m_modelFile) {
-        fclose(m_modelFile);
-      }
+  Deserialize(MLIRContext *context, const std::string &s)
+      : m_context(context), m_builder(OpBuilder(m_context)),
+        m_unknownLoc(UnknownLoc::get(m_context)) {
+    m_modelFile = fopen(s.c_str(), "r");
+    m_sourceFile = m_builder.getStringAttr(s);
   }
 
-///===----------------------------------------------------------------------===//
-/// Parse btor2 file
-///===----------------------------------------------------------------------===//
-  
+  ~Deserialize() {
+    if (m_model) {
+      btor2parser_delete(m_model);
+    }
+    if (m_modelFile) {
+      fclose(m_modelFile);
+    }
+  }
+
+  ///===----------------------------------------------------------------------===//
+  /// Parse btor2 file
+  ///===----------------------------------------------------------------------===//
+
   bool parseModelIsSuccessful();
 
-///===----------------------------------------------------------------------===//
-/// Create MLIR module
-///===----------------------------------------------------------------------===//
-  
+  ///===----------------------------------------------------------------------===//
+  /// Create MLIR module
+  ///===----------------------------------------------------------------------===//
+
   Value getFromCacheById(const int64_t id) {
     assert(valueAtIdIsInCache(id));
     return m_cache.at(id);
@@ -75,7 +76,7 @@ class Deserialize {
     assert(valueAtIdIsInCache(id));
   }
 
-  void setCacheWithId(const int64_t id, Operation * op) {
+  void setCacheWithId(const int64_t id, Operation *op) {
     assert(hasReturnValue(getLineById(id)));
     assert(op);
     assert(op->getNumResults() == 1);
@@ -83,21 +84,19 @@ class Deserialize {
     setCacheWithId(id, op->getResult(0));
   }
 
-  bool valueAtIdIsInCache(const int64_t id) {
-    return m_cache.count(id) != 0;
-  }
+  bool valueAtIdIsInCache(const int64_t id) { return m_cache.count(id) != 0; }
 
   OwningOpRef<mlir::FuncOp> buildMainFunction();
 
   btor::BitVecType getBVType(Type opType) {
     return opType.dyn_cast<btor::BitVecType>();
   }
-  
- private: 
-///===----------------------------------------------------------------------===//
-/// Parse btor2 file
-///===----------------------------------------------------------------------===//
-  
+
+private:
+  ///===----------------------------------------------------------------------===//
+  /// Parse btor2 file
+  ///===----------------------------------------------------------------------===//
+
   Btor2Parser *m_model = nullptr;
   FILE *m_modelFile = nullptr;
   StringAttr m_sourceFile = nullptr;
@@ -108,51 +107,55 @@ class Deserialize {
   std::vector<Btor2Line *> m_constraints;
   std::vector<Btor2Line *> m_lines;
 
-  std::map<int64_t, Btor2Line *> m_inits; // lets us quickly find the initLine from state->init
+  std::map<int64_t, Btor2Line *>
+      m_inits; // lets us quickly find the initLine from state->init
   std::map<int64_t, Value> m_cache;
   std::map<int64_t, Btor2Line *> m_sorts;
   std::map<unsigned, unsigned> m_inputs; // lineId -> input #
   std::map<unsigned, unsigned> map_bads; // lineId -> bad #
 
-  std::pair <int,int> parseModelLine(Btor2Line *l, std::pair <int,int> numberedCommands);
+  std::pair<int, int> parseModelLine(Btor2Line *l,
+                                     std::pair<int, int> numberedCommands);
 
-  Btor2Line * getLineById(unsigned id) {
-      assert(id < m_lines.size());
-      return m_lines.at(id);
+  Btor2Line *getLineById(unsigned id) {
+    assert(id < m_lines.size());
+    return m_lines.at(id);
   }
 
-  void setLineWithId(unsigned id, Btor2Line * line) {
-      assert(id < m_lines.size());
-      assert(!m_lines.at(id));
-      m_lines[id] = line;
+  void setLineWithId(unsigned id, Btor2Line *line) {
+    assert(id < m_lines.size());
+    assert(!m_lines.at(id));
+    m_lines[id] = line;
   }
-///===----------------------------------------------------------------------===//
-/// Create MLIR module
-///===----------------------------------------------------------------------===//
+  ///===----------------------------------------------------------------------===//
+  /// Create MLIR module
+  ///===----------------------------------------------------------------------===//
 
   MLIRContext *m_context;
   OpBuilder m_builder;
   Location m_unknownLoc;
-  
+
   void toOp(Btor2Line *line);
-  bool needsMLIROp(Btor2Line * line);
-  bool hasReturnValue(Btor2Line * line);
-  bool isStateArgumentOfInitOp(Btor2Line * cur, unsigned argumentId);
-  void createNegateLine(int64_t curAt, const unsigned lineId, const Value &child);
-  Operation * createMLIR(const Btor2Line *line, 
-                        const SmallVector<Value> &kids,
+  bool needsMLIROp(Btor2Line *line);
+  bool hasReturnValue(Btor2Line *line);
+  bool isStateArgumentOfInitOp(Btor2Line *cur, unsigned argumentId);
+  void createNegateLine(int64_t curAt, const unsigned lineId,
+                        const Value &child);
+  Operation *createMLIR(const Btor2Line *line, const SmallVector<Value> &kids,
                         const SmallVector<unsigned> &arguments);
   std::vector<Value> buildInitFunction(const std::vector<Type> &returnTypes);
-  std::vector<Value> buildNextFunction(const std::vector<Type> &returnTypes, 
-                                    Block *body);
-  std::vector<Value> collectReturnValuesForInit(const std::vector<Type> &returnTypes);
+  std::vector<Value> buildNextFunction(const std::vector<Type> &returnTypes,
+                                       Block *body);
+  std::vector<Value>
+  collectReturnValuesForInit(const std::vector<Type> &returnTypes);
 
   // Builder wrappers
   Type getTypeOf(const Btor2Line *line) {
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
-      auto shape = btor::BitVecType::get(m_context, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
-      auto elementType = btor::BitVecType::get(m_context,
-        m_sorts.at(line->sort.array.element)->sort.bitvec.width);
+      auto shape = btor::BitVecType::get(
+          m_context, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
+      auto elementType = btor::BitVecType::get(
+          m_context, m_sorts.at(line->sort.array.element)->sort.bitvec.width);
       return btor::ArrayType::get(m_context, shape, elementType);
       ;
     }
@@ -161,43 +164,43 @@ class Deserialize {
 
   // Binary Operations
   template <typename btorOp>
-  Operation * buildBinaryOp(const Value &lhs, const Value &rhs, const unsigned  lineId) {
-    auto res = m_builder.create<btorOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
-                                      lhs, rhs);
+  Operation *buildBinaryOp(const Value &lhs, const Value &rhs,
+                           const unsigned lineId) {
+    auto res = m_builder.create<btorOp>(
+        FileLineColLoc::get(m_sourceFile, lineId, 0), lhs, rhs);
     return res;
   }
 
   template <typename btorOp>
-  Operation * buildComparisonOp(const btor::BtorPredicate pred,
-                                const Value &lhs,
-                                const Value &rhs,
-                                const unsigned  lineId) {
-    auto res = m_builder.create<btorOp>(FileLineColLoc::get(m_sourceFile, lineId, 0), 
-                                       pred, lhs, rhs);
+  Operation *buildComparisonOp(const btor::BtorPredicate pred, const Value &lhs,
+                               const Value &rhs, const unsigned lineId) {
+    auto res = m_builder.create<btorOp>(
+        FileLineColLoc::get(m_sourceFile, lineId, 0), pred, lhs, rhs);
     return res;
   }
 
   template <typename btorOp>
-  Operation * buildOverflowOp(const Value &lhs, const Value &rhs, const unsigned  lineId) {
-    auto res = m_builder.create<btorOp>(FileLineColLoc::get(m_sourceFile, lineId, 0), 
-                                    btor::BitVecType::get(m_context, 1),
-                                    lhs, rhs);
+  Operation *buildOverflowOp(const Value &lhs, const Value &rhs,
+                             const unsigned lineId) {
+    auto res =
+        m_builder.create<btorOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
+                                 btor::BitVecType::get(m_context, 1), lhs, rhs);
     return res;
   }
 
-  Operation * buildConcatOp(const Value &lhs, const Value &rhs, const unsigned  lineId) {
-    auto newWidth = getBVType(lhs.getType()).getWidth() + getBVType(rhs.getType()).getWidth();
+  Operation *buildConcatOp(const Value &lhs, const Value &rhs,
+                           const unsigned lineId) {
+    auto newWidth = getBVType(lhs.getType()).getWidth() +
+                    getBVType(rhs.getType()).getWidth();
     Type resType = btor::BitVecType::get(m_context, newWidth);
-    auto res = m_builder.create<btor::ConcatOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
-                                                resType, lhs, rhs);
+    auto res = m_builder.create<btor::ConcatOp>(
+        FileLineColLoc::get(m_sourceFile, lineId, 0), resType, lhs, rhs);
     return res;
   }
 
   // Unary Operations
-  Operation * buildConstantOp(const unsigned width, 
-                            const std::string &str,
-                            const unsigned radix,
-                            const unsigned  lineId) {
+  Operation *buildConstantOp(const unsigned width, const std::string &str,
+                             const unsigned radix, const unsigned lineId) {
     Type type = btor::BitVecType::get(m_context, width);
     mlir::APInt value(width, 0, radix);
     if (str.compare("ones") == 0) {
@@ -208,24 +211,23 @@ class Deserialize {
       value = mlir::APInt(width, str, radix);
     }
     auto res = m_builder.create<btor::ConstantOp>(
-                        FileLineColLoc::get(m_sourceFile, lineId, 0),
-                        type, m_builder.getIntegerAttr(m_builder.getIntegerType(width), value));
+        FileLineColLoc::get(m_sourceFile, lineId, 0), type,
+        m_builder.getIntegerAttr(m_builder.getIntegerType(width), value));
     return res;
   }
 
   template <typename btorOp>
-  Operation * buildUnaryOp(const Value &val, const unsigned  lineId) {
+  Operation *buildUnaryOp(const Value &val, const unsigned lineId) {
     auto res = m_builder.create<btorOp>(
-                    FileLineColLoc::get(m_sourceFile, lineId, 0),
-                    val);
+        FileLineColLoc::get(m_sourceFile, lineId, 0), val);
     return res;
   }
 
   template <typename btorOp>
-  Operation * buildReductionOp(const Value &val, const unsigned  lineId) {
-    auto res = m_builder.create<btorOp>(
-                                FileLineColLoc::get(m_sourceFile, lineId, 0), 
-                                btor::BitVecType::get(m_context, 1), val);
+  Operation *buildReductionOp(const Value &val, const unsigned lineId) {
+    auto res =
+        m_builder.create<btorOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
+                                 btor::BitVecType::get(m_context, 1), val);
     return res;
   }
 
@@ -233,28 +235,26 @@ class Deserialize {
     m_builder.create<mlir::ReturnOp>(m_unknownLoc, results);
   }
 
-  Operation * buildInputOp(const unsigned width, const unsigned lineId) {
+  Operation *buildInputOp(const unsigned width, const unsigned lineId) {
     Type type = btor::BitVecType::get(m_context, width);
     auto res = m_builder.create<btor::InputOp>(
-        FileLineColLoc::get(m_sourceFile, lineId, 0),
-        type, 
-        m_builder.getIntegerAttr(m_builder.getIntegerType(64), m_inputs.at(lineId)));
+        FileLineColLoc::get(m_sourceFile, lineId, 0), type,
+        m_builder.getIntegerAttr(m_builder.getIntegerType(64),
+                                 m_inputs.at(lineId)));
     return res;
   }
 
-  Operation * buildAssertNotOp(const Value &val, const unsigned  lineId) {
+  Operation *buildAssertNotOp(const Value &val, const unsigned lineId) {
     auto res = m_builder.create<btor::AssertNotOp>(
-        FileLineColLoc::get(m_sourceFile, lineId, 0),
-        val,
-        m_builder.getIntegerAttr(m_builder.getIntegerType(64), map_bads.at(lineId)));
+        FileLineColLoc::get(m_sourceFile, lineId, 0), val,
+        m_builder.getIntegerAttr(m_builder.getIntegerType(64),
+                                 map_bads.at(lineId)));
     return res;
   }
 
   // Indexed Operations
-  Operation * buildSliceOp(const Value &val, 
-                        const int64_t upper, 
-                        const int64_t lower,
-                        const unsigned  lineId) {
+  Operation *buildSliceOp(const Value &val, const int64_t upper,
+                          const int64_t lower, const unsigned lineId) {
     btor::BitVecType opType = getBVType(val.getType());
     assert(opType.getWidth() > upper && upper >= lower);
     auto loc = FileLineColLoc::get(m_sourceFile, lineId, 0);
@@ -262,60 +262,52 @@ class Deserialize {
     auto resType = btor::BitVecType::get(m_context, upper - lower + 1);
     auto u = m_builder.create<btor::ConstantOp>(
         loc, opType,
-        m_builder.getIntegerAttr(m_builder.getIntegerType(opType.getWidth()), upper));
+        m_builder.getIntegerAttr(m_builder.getIntegerType(opType.getWidth()),
+                                 upper));
     assert(u && u->getNumResults() == 1);
     auto l = m_builder.create<btor::ConstantOp>(
-        loc, opType, 
-        m_builder.getIntegerAttr(m_builder.getIntegerType(opType.getWidth()), lower));
+        loc, opType,
+        m_builder.getIntegerAttr(m_builder.getIntegerType(opType.getWidth()),
+                                 lower));
     assert(l && l->getNumResults() == 1);
 
     auto res = m_builder.create<btor::SliceOp>(
-                            loc, resType, val,
-                            u->getResult(0), l->getResult(0));
+        loc, resType, val, u->getResult(0), l->getResult(0));
     return res;
   }
 
   template <typename btorOp>
-  Operation * buildExtOp(const Value &val,
-                        const unsigned width,
-                        const unsigned  lineId) {
-    auto res = m_builder.create<btorOp>(
-                            FileLineColLoc::get(m_sourceFile, lineId, 0), 
-                            val, btor::BitVecType::get(m_context, width));
+  Operation *buildExtOp(const Value &val, const unsigned width,
+                        const unsigned lineId) {
+    auto res =
+        m_builder.create<btorOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
+                                 val, btor::BitVecType::get(m_context, width));
     return res;
   }
 
   // Ternary Operations
-  Operation * buildIteOp(const Value &condition, 
-                        const Value &lhs, 
-                        const Value &rhs,
-                        const unsigned  lineId) {
+  Operation *buildIteOp(const Value &condition, const Value &lhs,
+                        const Value &rhs, const unsigned lineId) {
     auto res = m_builder.create<btor::IteOp>(
-                          FileLineColLoc::get(m_sourceFile, lineId, 0),
-                          condition, lhs, rhs);
+        FileLineColLoc::get(m_sourceFile, lineId, 0), condition, lhs, rhs);
     return res;
   }
 
   // Array Operations
-  Operation *buildReadOp(const Value &array,
-                        const Value &index,
-                        const unsigned  lineId) {
+  Operation *buildReadOp(const Value &array, const Value &index,
+                         const unsigned lineId) {
     auto elementType = array.getType().cast<btor::ArrayType>().getElement();
-    auto res =
-        m_builder.create<btor::ReadOp>(
-                        FileLineColLoc::get(m_sourceFile, lineId, 0),
-                        elementType, array, index);
+    auto res = m_builder.create<btor::ReadOp>(
+        FileLineColLoc::get(m_sourceFile, lineId, 0), elementType, array,
+        index);
     return res;
   }
 
-  Operation *buildWriteOp(const Value &array,
-                          const Value &index,
-                          const Value &value,
-                          const unsigned  lineId) {
+  Operation *buildWriteOp(const Value &array, const Value &index,
+                          const Value &value, const unsigned lineId) {
     auto res = m_builder.create<btor::WriteOp>(
-                            FileLineColLoc::get(m_sourceFile, lineId, 0),
-                            array.getType(),
-                            value, array, index);
+        FileLineColLoc::get(m_sourceFile, lineId, 0), array.getType(), value,
+        array, index);
     return res;
   }
 
@@ -324,21 +316,22 @@ class Deserialize {
     if (auto initLine = line->init)
       return nullptr;
     auto it = std::find(m_states.begin(), m_states.end(), line);
-    assert (it != m_states.end());
+    assert(it != m_states.end());
     auto index = it - m_states.begin();
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
-      auto res = m_builder.create<btor::ArrayOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
-                    getTypeOf(line));
+      auto res = m_builder.create<btor::ArrayOp>(
+          FileLineColLoc::get(m_sourceFile, lineId, 0), getTypeOf(line));
       return res;
     } else {
-      auto res = m_builder.create<btor::NDStateOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
-                    getTypeOf(line),
-                    m_builder.getIntegerAttr(m_builder.getIntegerType(64), index));
+      auto res = m_builder.create<btor::NDStateOp>(
+          FileLineColLoc::get(m_sourceFile, lineId, 0), getTypeOf(line),
+          m_builder.getIntegerAttr(m_builder.getIntegerType(64), index));
       return res;
     }
   }
 
-  void buildInitOp(const Btor2Line *line, const Value &initValue, const unsigned lineId) {
+  void buildInitOp(const Btor2Line *line, const Value &initValue,
+                   const unsigned lineId) {
     auto stateId = line->args[0];
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
       auto initValueType = initValue.getType();
@@ -346,8 +339,9 @@ class Deserialize {
         setCacheWithId(stateId, initValue);
         return;
       }
-      auto res = m_builder.create<btor::InitArrayOp>(FileLineColLoc::get(m_sourceFile, lineId, 0),
-                    getTypeOf(line), initValue);
+      auto res = m_builder.create<btor::InitArrayOp>(
+          FileLineColLoc::get(m_sourceFile, lineId, 0), getTypeOf(line),
+          initValue);
       assert(res);
       assert(res->getNumResults() == 1);
       setCacheWithId(stateId, res->getResult(0));

--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -150,10 +150,12 @@ class Deserialize {
   // Builder wrappers
   Type getTypeOf(const Btor2Line *line) {
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
-      unsigned indexWidth = pow(2, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
+      // unsigned indexWidth = pow(2, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
+      auto shape = btor::BitVecType::get(m_context, m_sorts.at(line->sort.array.index)->sort.bitvec.width);
       auto elementType = btor::BitVecType::get(m_context,
         m_sorts.at(line->sort.array.element)->sort.bitvec.width);
-      return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
+      return btor::ArrayType::get(m_context, shape, elementType);
+      // return VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
       ;
     }
     return btor::BitVecType::get(m_context, line->sort.bitvec.width);
@@ -300,7 +302,7 @@ class Deserialize {
   Operation *buildReadOp(const Value &array,
                         const Value &index,
                         const unsigned  lineId) {
-    auto elementType = array.getType().cast<VectorType>().getElementType();
+    auto elementType = array.getType().cast<btor::ArrayType>().getElement();
     auto res =
         m_builder.create<btor::ReadOp>(
                         FileLineColLoc::get(m_sourceFile, lineId, 0),
@@ -342,7 +344,7 @@ class Deserialize {
     auto stateId = line->args[0];
     if (line->sort.tag == BTOR2_TAG_SORT_array) {
       auto initValueType = initValue.getType();
-      if (initValueType.isa<VectorType>()) {
+      if (initValueType.isa<btor::ArrayType>()) {
         setCacheWithId(stateId, initValue);
         return;
       }

--- a/lib/Conversion/BtorToVector/BtorToVector.cpp
+++ b/lib/Conversion/BtorToVector/BtorToVector.cpp
@@ -2,9 +2,12 @@
 #include "Dialect/Btor/IR/Btor.h"
 
 #include "../PassDetail.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/VectorPattern.h"
+// #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 using namespace mlir;
 using namespace mlir::btor;
@@ -13,42 +16,53 @@ using namespace mlir::btor;
 // Lowering Declarations
 //===----------------------------------------------------------------------===//
 
-struct InitArrayLowering : public OpConversionPattern<mlir::btor::InitArrayOp> {
-  using OpConversionPattern<mlir::btor::InitArrayOp>::OpConversionPattern;
+struct InitArrayLowering : public ConvertOpToLLVMPattern<mlir::btor::InitArrayOp> {
+  using ConvertOpToLLVMPattern<mlir::btor::InitArrayOp>::ConvertOpToLLVMPattern;
   LogicalResult
   matchAndRewrite(mlir::btor::InitArrayOp initArrayOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
 
-struct ReadOpLowering : public OpConversionPattern<mlir::btor::ReadOp> {
-  using OpConversionPattern<mlir::btor::ReadOp>::OpConversionPattern;
+struct ReadOpLowering : public ConvertOpToLLVMPattern<mlir::btor::ReadOp> {
+  using ConvertOpToLLVMPattern<mlir::btor::ReadOp>::ConvertOpToLLVMPattern;
   LogicalResult
   matchAndRewrite(mlir::btor::ReadOp readOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
 
-struct WriteOpLowering : public OpConversionPattern<mlir::btor::WriteOp> {
-  using OpConversionPattern<mlir::btor::WriteOp>::OpConversionPattern;
+struct WriteOpLowering : public ConvertOpToLLVMPattern<mlir::btor::WriteOp> {
+  using ConvertOpToLLVMPattern<mlir::btor::WriteOp>::ConvertOpToLLVMPattern;
   LogicalResult
   matchAndRewrite(mlir::btor::WriteOp writeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
 
-LogicalResult
-InitArrayLowering::matchAndRewrite(mlir::btor::InitArrayOp initArrayOp, OpAdaptor adaptor,
-                                 ConversionPatternRewriter &rewriter) const {
-  btor::ArrayType type = initArrayOp.getType();
-  unsigned indexWidth = pow(2, type.getShape().getWidth());
-  auto elementType =  ::IntegerType::get(type.getContext(), type.getElement().getWidth());
-  // return MemRefType::get(ArrayRef<int64_t>{indexWidth}, elementType);
-  VectorType opType = VectorType::get(ArrayRef<int64_t>{indexWidth}, elementType);
+struct VectorInitArrayOpLowering
+    : public ConvertOpToLLVMPattern<mlir::btor::VectorInitArrayOp> {
+  using ConvertOpToLLVMPattern<mlir::btor::VectorInitArrayOp>::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(mlir::btor::VectorInitArrayOp vecInitArrayOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
 
-  auto callOp = rewriter.create<vector::BroadcastOp>(initArrayOp.getLoc(), opType, adaptor.init());
-  auto result = callOp.getResult();
-  initArrayOp.replaceAllUsesWith(result);
-  rewriter.replaceOp(initArrayOp, result);
-  // rewriter.replaceOpWithNewOp<vector::BroadcastOp>(
-  //       initArrayOp, opType, adaptor.init());
+//===----------------------------------------------------------------------===//
+// Lowering Definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+InitArrayLowering::matchAndRewrite(mlir::btor::InitArrayOp initArrayOp,
+                                   OpAdaptor adaptor,
+                                   ConversionPatternRewriter &rewriter) const {
+  auto arrayType = typeConverter->convertType(initArrayOp.getType());
+
+  // auto callOp =
+  // rewriter.create<btor::VectorInitArrayOp>(initArrayOp.getLoc(), typeConverter->convertType(arrayType),
+  // adaptor.init()); auto result = callOp.getResult();
+  // initArrayOp.replaceAllUsesWith(result);
+  // rewriter.replaceOp(initArrayOp, result);
+  rewriter.replaceOpWithNewOp<mlir::btor::VectorInitArrayOp>(
+      initArrayOp, arrayType, adaptor.init());
   return success();
 }
 
@@ -65,8 +79,16 @@ LogicalResult
 WriteOpLowering::matchAndRewrite(mlir::btor::WriteOp writeOp, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {
   rewriter.replaceOpWithNewOp<vector::InsertElementOp>(
-      writeOp, writeOp.base().getType(), writeOp.value(),
-      writeOp.base(), writeOp.index());
+      writeOp, writeOp.base().getType(), writeOp.value(), writeOp.base(),
+      writeOp.index());
+  return success();
+}
+
+LogicalResult VectorInitArrayOpLowering::matchAndRewrite(
+    mlir::btor::VectorInitArrayOp vecInitArrayOp, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<vector::BroadcastOp>(
+      vecInitArrayOp, vecInitArrayOp.getType(), vecInitArrayOp.init());
   return success();
 }
 
@@ -75,8 +97,9 @@ WriteOpLowering::matchAndRewrite(mlir::btor::WriteOp writeOp, OpAdaptor adaptor,
 //===----------------------------------------------------------------------===//
 
 void mlir::btor::populateBtorToVectorConversionPatterns(
-    RewritePatternSet &patterns) {
-  patterns.add<ReadOpLowering, WriteOpLowering, InitArrayLowering>(patterns.getContext());
+    BtorToLLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<ReadOpLowering, WriteOpLowering, InitArrayLowering,
+               VectorInitArrayOpLowering>(converter);
 }
 
 namespace {
@@ -84,12 +107,14 @@ struct ConvertBtorToVectorPass
     : public ConvertBtorToVectorBase<ConvertBtorToVectorPass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    populateBtorToVectorConversionPatterns(patterns);
     LLVMConversionTarget target(getContext());
+    BtorToLLVMTypeConverter converter(&getContext());
 
+    mlir::btor::populateBtorToVectorConversionPatterns(converter, patterns);
+    mlir::populateStdToLLVMConversionPatterns(converter, patterns);
     /// Configure conversion to lower out btor; Anything else is fine.
     // init operators
-    target.addIllegalOp<btor::InitArrayOp>();
+    target.addIllegalOp<btor::InitArrayOp, btor::VectorInitArrayOp>();
 
     /// indexed operators
     target.addIllegalOp<btor::ReadOp, btor::WriteOp>();

--- a/lib/Conversion/BtorToVector/BtorToVector.cpp
+++ b/lib/Conversion/BtorToVector/BtorToVector.cpp
@@ -94,7 +94,7 @@ WriteOpLowering::matchAndRewrite(mlir::btor::WriteOp writeOp, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter) const {
   auto resType = typeConverter->convertType(writeOp.base().getType());
   rewriter.replaceOpWithNewOp<mlir::btor::VectorWriteOp>(
-    writeOp, resType, adaptor.value(), adaptor.base(), adaptor.index());
+      writeOp, resType, adaptor.value(), adaptor.base(), adaptor.index());
   return success();
 }
 

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -621,6 +621,44 @@ static ParseResult parseVectorReadOp(OpAsmParser &parser, OperationState &result
 }
 
 //===----------------------------------------------------------------------===//
+// Write Operations using Vectors
+//===----------------------------------------------------------------------===//
+
+void printVectorWriteOp(OpAsmPrinter &p, VectorWriteOp &op) {
+  p << " " << op.value() << ", " << op.base() << "[" << op.index() << "]";
+  p.printOptionalAttrDict(op->getAttrs());
+  p << " : " << op.result().getType();
+}
+
+template <typename Op>
+LogicalResult verifyVectorWriteOp(Op op) {
+  auto type = op.value().getType().getIntOrFloatBitWidth();
+  // The value's type must match the array's element type.
+  if (op.getArrayType().getElementType().getIntOrFloatBitWidth() != type) {
+    return op.emitOpError() << "element type of the array must match "
+                         << " bitwidth of given value: " << type;
+  }
+  return success();
+}
+
+static ParseResult parseVectorWriteOp(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::OperandType value, base, index;
+  VectorType resultType; IntegerType indexType;
+  if (parser.parseOperand(value) || parser.parseComma() ||
+      parser.parseOperand(base) || parser.parseLSquare() || 
+      parser.parseOperand(index) || parser.parseRSquare() ||
+      parser.parseOptionalAttrDict(result.attributes) || 
+      parser.parseColon() || parser.parseType(resultType))
+    return failure();
+
+  result.addTypes(resultType);
+  indexType = parser.getBuilder().getIntegerType(log2(resultType.getShape()[0]));
+  return parser.resolveOperands({value, base, index}, 
+                                {resultType.getElementType(), resultType, indexType},
+                                parser.getNameLoc(), result.operands);
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -529,6 +529,51 @@ LogicalResult verifyAssertNotOp(Op op) {
 }
 
 //===----------------------------------------------------------------------===//
+// Initialzied Array Operations using Vectors
+//===----------------------------------------------------------------------===//
+
+static void printVectorInitArrayOp(OpAsmPrinter &p, VectorInitArrayOp &op) {
+  p << " " << op.init();
+  p.printOptionalAttrDict(op->getAttrs());
+  p << " : " << op.result().getType();
+}
+
+template <typename Op>
+static LogicalResult verifyVectorInitArrayOp(Op op) {
+  auto initType = op.init().getType();
+  auto initWidth = initType.getIntOrFloatBitWidth();
+  auto elementType = op.getArrayType().getElementType();
+  if (elementType.getIntOrFloatBitWidth() != initWidth) {
+    return op.emitOpError() << "element type of the array must match "
+                         << " bitwidth of given value: " << initWidth;
+  }
+  if (op.getArrayType().getShape().size() != 1) {
+    return op.emitOpError() << "provide only one shape attribute ";
+  }
+  auto shape = op.getArrayType().getShape()[0];
+  auto indicator = shape & (shape - 1);
+  if (indicator != 0) {
+    return op.emitOpError() << "given shape: " <<  shape 
+                         << " has to be a power of two";
+  }
+  return success();
+}
+
+static ParseResult parseVectorInitArrayOp(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::OperandType init;
+  VectorType resultType;
+  if (parser.parseOperand(init) ||
+      parser.parseOptionalAttrDict(result.attributes) || 
+      parser.parseColon() || parser.parseType(resultType))
+    return failure();
+
+  result.addTypes(resultType);
+  return parser.resolveOperands({init}, 
+                                {resultType.getElementType()},
+                                parser.getNameLoc(), result.operands);
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -9,13 +9,13 @@
 
 #include "Dialect/Btor/IR/Btor.h"
 #include "Dialect/Btor/IR/BtorTypes.h"
-#include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/TypeUtilities.h"
-#include "mlir/IR/Operation.h"
 #include "mlir/Dialect/CommonFolders.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "llvm/ADT/SmallString.h"
 
 #include "llvm/ADT/APSInt.h"
@@ -27,7 +27,7 @@ namespace {
 btor::BitVecType getBVType(Type opType) {
   return opType.dyn_cast<btor::BitVecType>();
 }
-}
+} // namespace
 
 /// A custom unary operation printer that omits the "std." prefix from the
 /// operation names.
@@ -42,18 +42,17 @@ static void printBtorUnaryOp(OpAsmPrinter &p, Operation *op) {
 
 /// A custom unary operation parser that ensures result has type i1
 static ParseResult parseUnaryDifferentResultOp(OpAsmParser &parser,
-                                  OperationState &result) {  
+                                               OperationState &result) {
   Type operandType;
   SmallVector<OpAsmParser::OperandType, 1> operands;
   if (parser.parseOperandList(operands, /*requiredOperandCount=*/1) ||
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.parseColonType(operandType))
     return failure();
-  
+
   result.addTypes(btor::BitVecType::get(parser.getContext(), 1));
-  return parser.resolveOperands(operands,
-                                {operandType},
-                                parser.getNameLoc(), result.operands);
+  return parser.resolveOperands(operands, {operandType}, parser.getNameLoc(),
+                                result.operands);
 }
 
 //===----------------------------------------------------------------------===//
@@ -75,7 +74,7 @@ static ParseResult parseSliceOp(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 3> operands;
   if (parser.parseOperandList(operands, /*requiredOperandCount=*/3) ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parser.parseType(operandType) || parser.parseOptionalComma() || 
+      parser.parseType(operandType) || parser.parseOptionalComma() ||
       parser.parseType(resultType))
     return failure();
 
@@ -90,9 +89,11 @@ static void printSliceOp(OpAsmPrinter &p, Operation *op) {
   assert(op->getNumOperands() == 3 && "slice op should have one operand");
   assert(op->getNumResults() == 1 && "slice op should have one result");
 
-  p << ' ' << op->getOperand(0) << ", " << op->getOperand(1) << ", " << op->getOperand(2);
+  p << ' ' << op->getOperand(0) << ", " << op->getOperand(1) << ", "
+    << op->getOperand(2);
   p.printOptionalAttrDict(op->getAttrs());
-  p << " : " << op->getOperand(0).getType() << ", " << op->getResult(0).getType();
+  p << " : " << op->getOperand(0).getType() << ", "
+    << op->getResult(0).getType();
 }
 
 template <typename ValType, typename Op>
@@ -102,7 +103,8 @@ static LogicalResult verifySliceOp(Op op) {
 
   if (srcType.cast<ValType>().getWidth() < dstType.cast<ValType>().getWidth())
     return op.emitError("result type ")
-           << dstType << " must be smaller or equal to the operand type " << srcType;
+           << dstType << " must be smaller or equal to the operand type "
+           << srcType;
 
   return success();
 }
@@ -148,17 +150,16 @@ OpFoldResult ConstantOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 
 static ParseResult parseBinaryOverflowOp(OpAsmParser &parser,
-                                  OperationState &result) {  
+                                         OperationState &result) {
   Type operandType;
   SmallVector<OpAsmParser::OperandType, 2> operands;
   if (parser.parseOperandList(operands, /*requiredOperandCount=*/2) ||
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.parseColonType(operandType))
     return failure();
-  
+
   result.addTypes(btor::BitVecType::get(parser.getContext(), 1));
-  return parser.resolveOperands(operands,
-                                {operandType, operandType},
+  return parser.resolveOperands(operands, {operandType, operandType},
                                 parser.getNameLoc(), result.operands);
 }
 
@@ -198,14 +199,13 @@ static ParseResult parseConcatOp(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 1> operands;
   if (parser.parseOperandList(operands, /*requiredOperandCount=*/2) ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parser.parseType(firstOperandType) || parser.parseOptionalComma() || 
-      parser.parseType(secondOperandType) || parser.parseOptionalComma() || 
+      parser.parseType(firstOperandType) || parser.parseOptionalComma() ||
+      parser.parseType(secondOperandType) || parser.parseOptionalComma() ||
       parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
-  return parser.resolveOperands(operands,
-                                {firstOperandType, secondOperandType},
+  return parser.resolveOperands(operands, {firstOperandType, secondOperandType},
                                 parser.getNameLoc(), result.operands);
 }
 
@@ -216,7 +216,7 @@ static void printConcatOp(OpAsmPrinter &p, Operation *op) {
   p.printOptionalAttrDict(op->getAttrs());
 
   // Now we can output the types for all operands and the result.
-  p << " : " << op->getOperand(0).getType() << ", " 
+  p << " : " << op->getOperand(0).getType() << ", "
     << op->getOperand(1).getType() << ", " << op->getResult(0).getType();
 }
 
@@ -226,11 +226,12 @@ static LogicalResult verifyConcatOp(Op op) {
   Type secondType = getElementTypeOrSelf(op.rhs().getType());
   Type dstType = getElementTypeOrSelf(op.getType());
 
-  auto sumOfTypes = firstType.cast<ValType>().getWidth() + 
-              secondType.cast<ValType>().getWidth();
+  auto sumOfTypes = firstType.cast<ValType>().getWidth() +
+                    secondType.cast<ValType>().getWidth();
   if (sumOfTypes != dstType.cast<ValType>().getWidth())
-    return op.emitError("sum of ") << firstType << " and "
-         << secondType << " must be equal to operand type " << dstType;
+    return op.emitError("sum of ")
+           << firstType << " and " << secondType
+           << " must be equal to operand type " << dstType;
 
   return success();
 }
@@ -244,7 +245,7 @@ static void printInputOp(OpAsmPrinter &p, mlir::btor::InputOp &op) {
   p << " : " << op.result().getType();
 }
 
-static ParseResult parseInputOp(OpAsmParser &parser, OperationState &result) {  
+static ParseResult parseInputOp(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::OperandType> ops;
   NamedAttrList attrs;
   Attribute idAttr;
@@ -253,13 +254,12 @@ static ParseResult parseInputOp(OpAsmParser &parser, OperationState &result) {
   Type i64Type = parser.getBuilder().getIntegerType(64);
 
   if (parser.parseAttribute(idAttr, i64Type, "id", attrs) ||
-      parser.parseOptionalAttrDict(attrs) || 
-      parser.parseColonType(type))
-      return failure();
+      parser.parseOptionalAttrDict(attrs) || parser.parseColonType(type))
+    return failure();
 
   if (!idAttr.isa<mlir::IntegerAttr>())
-      return parser.emitError(parser.getNameLoc(),
-                              "expected integer id attribute");
+    return parser.emitError(parser.getNameLoc(),
+                            "expected integer id attribute");
 
   result.attributes = attrs;
   result.addTypes({type});
@@ -275,7 +275,8 @@ static void printNDStateOpOp(OpAsmPrinter &p, mlir::btor::NDStateOp &op) {
   p << " : " << op.result().getType();
 }
 
-static ParseResult parseNDStateOpOp(OpAsmParser &parser, OperationState &result) {  
+static ParseResult parseNDStateOpOp(OpAsmParser &parser,
+                                    OperationState &result) {
   SmallVector<OpAsmParser::OperandType> ops;
   NamedAttrList attrs;
   Attribute idAttr;
@@ -284,13 +285,12 @@ static ParseResult parseNDStateOpOp(OpAsmParser &parser, OperationState &result)
   Type i64Type = parser.getBuilder().getIntegerType(64);
 
   if (parser.parseAttribute(idAttr, i64Type, "id", attrs) ||
-      parser.parseOptionalAttrDict(attrs) || 
-      parser.parseColonType(type))
-      return failure();
+      parser.parseOptionalAttrDict(attrs) || parser.parseColonType(type))
+    return failure();
 
   if (!idAttr.isa<mlir::IntegerAttr>())
-      return parser.emitError(parser.getNameLoc(),
-                              "expected integer id attribute");
+    return parser.emitError(parser.getNameLoc(),
+                            "expected integer id attribute");
 
   result.attributes = attrs;
   result.addTypes({type});
@@ -301,17 +301,7 @@ static ParseResult parseNDStateOpOp(OpAsmParser &parser, OperationState &result)
 // Array Operations
 //===----------------------------------------------------------------------===//
 
-template <typename Op>
-static LogicalResult verifyArrayOp(Op op) {
-  // if (op.getArrayType().getShape().size() != 1) {
-  //   return op.emitOpError() << "provide only one shape attribute ";
-  // }
-  // auto shape = op.getArrayType().getShape()[0];
-  // auto indicator = shape & (shape - 1);
-  // if (indicator != 0) {
-  //   return op.emitOpError() << "given shape: " <<  shape 
-  //                        << " has to be a power of two";
-  // }
+template <typename Op> static LogicalResult verifyArrayOp(Op op) {
   return success();
 }
 
@@ -325,39 +315,29 @@ static void printInitArrayOp(OpAsmPrinter &p, InitArrayOp &op) {
   p << " : " << op.result().getType();
 }
 
-template <typename Op>
-static LogicalResult verifyInitArrayOp(Op op) {
+template <typename Op> static LogicalResult verifyInitArrayOp(Op op) {
   auto initType = getBVType(op.init().getType());
   auto initWidth = initType.getWidth();
   // The value's width must match the array's element initWidth.
   auto elementType = op.getArrayType().getElement();
   if (elementType.getWidth() != initWidth) {
     return op.emitOpError() << "element initWidth of the array must match "
-                         << " bitwidth of given value: " << initWidth;
+                            << " bitwidth of given value: " << initWidth;
   }
-  // if (op.getArrayType().getShape().size() != 1) {
-  //   return op.emitOpError() << "provide only one shape attribute ";
-  // }
-  // auto shape = op.getArrayType().getShape()[0];
-  // auto indicator = shape & (shape - 1);
-  // if (indicator != 0) {
-  //   return op.emitOpError() << "given shape: " <<  shape 
-  //                        << " has to be a power of two";
-  // }
   return success();
 }
 
-static ParseResult parseInitArrayOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseInitArrayOp(OpAsmParser &parser,
+                                    OperationState &result) {
   OpAsmParser::OperandType init;
   btor::ArrayType resultType;
   if (parser.parseOperand(init) ||
-      parser.parseOptionalAttrDict(result.attributes) || 
-      parser.parseColon() || parser.parseType(resultType))
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
-  return parser.resolveOperands({init}, 
-                                {resultType.getElement()},
+  return parser.resolveOperands({init}, {resultType.getElement()},
                                 parser.getNameLoc(), result.operands);
 }
 
@@ -371,42 +351,32 @@ static void printReadOp(OpAsmPrinter &p, ReadOp &op) {
   p << " : " << op.base().getType() << ", " << op.result().getType();
 }
 
-template <typename Op>
-static LogicalResult verifyReadOp(Op op) {
+template <typename Op> static LogicalResult verifyReadOp(Op op) {
   // auto type = op.result().getType().getIntOrFloatBitWidth();
   auto resultType = getBVType(op.result().getType());
   auto resWidth = resultType.getWidth();
   // The value's type must match the return type.
   if (op.getArrayType().getElement().getWidth() != resWidth) {
     return op.emitOpError() << "element type of the array must match "
-                         << " bitwidth of return type: " << resWidth;
+                            << " bitwidth of return type: " << resWidth;
   }
-  // if (op.getArrayType().getShape().size() != 1) {
-  //   return op.emitOpError() << "provide only one shape attribute ";
-  // }
-  // auto shape = op.getArrayType().getShape()[0];
-  // auto indicator = shape & (shape - 1);
-  // if (indicator != 0) {
-  //   return op.emitOpError() << "given shape: " <<  shape 
-  //                        << " has to be a power of two";
-  // }
   return success();
 }
 
 static ParseResult parseReadOp(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::OperandType base, index;
-  btor::ArrayType baseType; btor::BitVecType indexType;
+  btor::ArrayType baseType;
+  btor::BitVecType indexType;
   btor::BitVecType resultType;
-  if (parser.parseOperand(base) || parser.parseLSquare() || 
+  if (parser.parseOperand(base) || parser.parseLSquare() ||
       parser.parseOperand(index) || parser.parseRSquare() ||
-      parser.parseOptionalAttrDict(result.attributes) || 
-      parser.parseColon() || parser.parseType(baseType) ||
-      parser.parseOptionalComma() || parser.parseType(resultType))
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(baseType) || parser.parseOptionalComma() ||
+      parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
   indexType = baseType.getShape();
-  // indexType = parser.getBuilder().getIntegerType(log2(baseType.getShape()[0]));
   return parser.resolveOperands({base, index}, {baseType, indexType},
                                 parser.getNameLoc(), result.operands);
 }
@@ -421,67 +391,61 @@ void printWriteOp(OpAsmPrinter &p, WriteOp &op) {
   p << " : " << op.result().getType();
 }
 
-template <typename Op>
-LogicalResult verifyWriteOp(Op op) {
+template <typename Op> LogicalResult verifyWriteOp(Op op) {
   // auto type = op.value().getType().getIntOrFloatBitWidth();
   auto valType = getBVType(op.value().getType());
   auto valWidth = valType.getWidth();
   // The value's type must match the array's element type.
   if (op.getArrayType().getElement().getWidth() != valWidth) {
     return op.emitOpError() << "element type of the array must match "
-                         << " bitwidth of return type: " << valWidth;
+                            << " bitwidth of return type: " << valWidth;
   }
-  // // The value's type must match the array's element type.
-  // if (op.getArrayType().getElementType().getIntOrFloatBitWidth() != type) {
-  //   return op.emitOpError() << "element type of the array must match "
-  //                        << " bitwidth of given value: " << type;
-  // }
   return success();
 }
 
 static ParseResult parseWriteOp(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::OperandType value, base, index;
-  btor::ArrayType resultType; btor::BitVecType indexType;
+  btor::ArrayType resultType;
+  btor::BitVecType indexType;
   if (parser.parseOperand(value) || parser.parseComma() ||
-      parser.parseOperand(base) || parser.parseLSquare() || 
+      parser.parseOperand(base) || parser.parseLSquare() ||
       parser.parseOperand(index) || parser.parseRSquare() ||
-      parser.parseOptionalAttrDict(result.attributes) || 
-      parser.parseColon() || parser.parseType(resultType))
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
   indexType = resultType.getShape();
-  // indexType = parser.getBuilder().getIntegerType(log2(resultType.getShape()[0]));
-  return parser.resolveOperands({value, base, index}, 
-                                {resultType.getElement(), resultType, indexType},
-                                parser.getNameLoc(), result.operands);
+  return parser.resolveOperands(
+      {value, base, index}, {resultType.getElement(), resultType, indexType},
+      parser.getNameLoc(), result.operands);
 }
 
 //===----------------------------------------------------------------------===//
 // Constant Operations
 //===----------------------------------------------------------------------===//
 
-template <typename Op>
-LogicalResult verifyConstantOp(Op op) {
+template <typename Op> LogicalResult verifyConstantOp(Op op) {
   btor::BitVecType resultType = getBVType(op.result().getType());
   auto attributeType = op.valueAttr().getType();
   if (resultType && attributeType &&
-    resultType.getWidth() == attributeType.getIntOrFloatBitWidth()) {
-      return success();
-  }
-  else return failure();
+      resultType.getWidth() == attributeType.getIntOrFloatBitWidth()) {
+    return success();
+  } else
+    return failure();
 }
 
 //===----------------------------------------------------------------------===//
 // Constraint Operations
 //===----------------------------------------------------------------------===//
 
-template <typename Op>
-LogicalResult verifyConstraintOp(Op op) {;
+template <typename Op> LogicalResult verifyConstraintOp(Op op) {
+  ;
   btor::BitVecType resultType = getBVType(op.constraint().getType());
   if (resultType.getWidth() != 1) {
-    return op.emitOpError() << "result must be bit vector of length 1 instead got length of "
-                         << resultType.getWidth();
+    return op.emitOpError()
+           << "result must be bit vector of length 1 instead got length of "
+           << resultType.getWidth();
   }
   return success();
 }
@@ -490,12 +454,13 @@ LogicalResult verifyConstraintOp(Op op) {;
 // Boolean Operations
 //===----------------------------------------------------------------------===//
 
-template <typename Op>
-LogicalResult verifyBooleanOp(Op op) {;
+template <typename Op> LogicalResult verifyBooleanOp(Op op) {
+  ;
   btor::BitVecType resultType = getBVType(op.result().getType());
   if (resultType.getWidth() != 1) {
-    return op.emitOpError() << "result must be bit vector of length 1 instead got length of "
-                         << resultType.getWidth();
+    return op.emitOpError()
+           << "result must be bit vector of length 1 instead got length of "
+           << resultType.getWidth();
   }
   return success();
 }
@@ -504,12 +469,12 @@ LogicalResult verifyBooleanOp(Op op) {;
 // Compare Operations
 //===----------------------------------------------------------------------===//
 
-template <typename Op>
-LogicalResult verifyCmpOp(Op op) {
+template <typename Op> LogicalResult verifyCmpOp(Op op) {
   unsigned resultLength = getBVType(op.result().getType()).getWidth();
-  if(resultLength != 1){
-    return op.emitOpError() << "result must be bit vector of length 1 instead got length of "
-                         << resultLength;
+  if (resultLength != 1) {
+    return op.emitOpError()
+           << "result must be bit vector of length 1 instead got length of "
+           << resultLength;
   }
   return success();
 }
@@ -518,12 +483,12 @@ LogicalResult verifyCmpOp(Op op) {
 // AssertNot Operations
 //===----------------------------------------------------------------------===//
 
-template <typename Op>
-LogicalResult verifyAssertNotOp(Op op) {
+template <typename Op> LogicalResult verifyAssertNotOp(Op op) {
   unsigned resultLength = getBVType(op.arg().getType()).getWidth();
-  if(resultLength != 1){
-    return op.emitOpError() << "result must be bit vector of length 1 instead got length of "
-                         << resultLength;
+  if (resultLength != 1) {
+    return op.emitOpError()
+           << "result must be bit vector of length 1 instead got length of "
+           << resultLength;
   }
   return success();
 }
@@ -538,14 +503,13 @@ static void printVectorInitArrayOp(OpAsmPrinter &p, VectorInitArrayOp &op) {
   p << " : " << op.result().getType();
 }
 
-template <typename Op>
-static LogicalResult verifyVectorInitArrayOp(Op op) {
+template <typename Op> static LogicalResult verifyVectorInitArrayOp(Op op) {
   auto initType = op.init().getType();
   auto initWidth = initType.getIntOrFloatBitWidth();
   auto elementType = op.getArrayType().getElementType();
   if (elementType.getIntOrFloatBitWidth() != initWidth) {
     return op.emitOpError() << "element type of the array must match "
-                         << " bitwidth of given value: " << initWidth;
+                            << " bitwidth of given value: " << initWidth;
   }
   if (op.getArrayType().getShape().size() != 1) {
     return op.emitOpError() << "provide only one shape attribute ";
@@ -553,23 +517,23 @@ static LogicalResult verifyVectorInitArrayOp(Op op) {
   auto shape = op.getArrayType().getShape()[0];
   auto indicator = shape & (shape - 1);
   if (indicator != 0) {
-    return op.emitOpError() << "given shape: " <<  shape 
-                         << " has to be a power of two";
+    return op.emitOpError()
+           << "given shape: " << shape << " has to be a power of two";
   }
   return success();
 }
 
-static ParseResult parseVectorInitArrayOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseVectorInitArrayOp(OpAsmParser &parser,
+                                          OperationState &result) {
   OpAsmParser::OperandType init;
   VectorType resultType;
   if (parser.parseOperand(init) ||
-      parser.parseOptionalAttrDict(result.attributes) || 
-      parser.parseColon() || parser.parseType(resultType))
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
-  return parser.resolveOperands({init}, 
-                                {resultType.getElementType()},
+  return parser.resolveOperands({init}, {resultType.getElementType()},
                                 parser.getNameLoc(), result.operands);
 }
 
@@ -583,13 +547,12 @@ static void printVectorReadOp(OpAsmPrinter &p, VectorReadOp &op) {
   p << " : " << op.base().getType() << ", " << op.result().getType();
 }
 
-template <typename Op>
-static LogicalResult verifyVectorReadOp(Op op) {
+template <typename Op> static LogicalResult verifyVectorReadOp(Op op) {
   auto type = op.result().getType().getIntOrFloatBitWidth();
   // The value's type must match the return type.
   if (op.getArrayType().getElementType().getIntOrFloatBitWidth() != type) {
     return op.emitOpError() << "element type of the array must match "
-                         << " bitwidth of return type: " << type;
+                            << " bitwidth of return type: " << type;
   }
   if (op.getArrayType().getShape().size() != 1) {
     return op.emitOpError() << "provide only one shape attribute ";
@@ -597,21 +560,23 @@ static LogicalResult verifyVectorReadOp(Op op) {
   auto shape = op.getArrayType().getShape()[0];
   auto indicator = shape & (shape - 1);
   if (indicator != 0) {
-    return op.emitOpError() << "given shape: " <<  shape 
-                         << " has to be a power of two";
+    return op.emitOpError()
+           << "given shape: " << shape << " has to be a power of two";
   }
   return success();
 }
 
-static ParseResult parseVectorReadOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseVectorReadOp(OpAsmParser &parser,
+                                     OperationState &result) {
   OpAsmParser::OperandType base, index;
-  VectorType baseType; IntegerType indexType;
+  VectorType baseType;
+  IntegerType indexType;
   Type resultType;
-  if (parser.parseOperand(base) || parser.parseLSquare() || 
+  if (parser.parseOperand(base) || parser.parseLSquare() ||
       parser.parseOperand(index) || parser.parseRSquare() ||
-      parser.parseOptionalAttrDict(result.attributes) || 
-      parser.parseColon() || parser.parseType(baseType) ||
-      parser.parseOptionalComma() || parser.parseType(resultType))
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(baseType) || parser.parseOptionalComma() ||
+      parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
@@ -630,32 +595,35 @@ void printVectorWriteOp(OpAsmPrinter &p, VectorWriteOp &op) {
   p << " : " << op.result().getType();
 }
 
-template <typename Op>
-LogicalResult verifyVectorWriteOp(Op op) {
+template <typename Op> LogicalResult verifyVectorWriteOp(Op op) {
   auto type = op.value().getType().getIntOrFloatBitWidth();
   // The value's type must match the array's element type.
   if (op.getArrayType().getElementType().getIntOrFloatBitWidth() != type) {
     return op.emitOpError() << "element type of the array must match "
-                         << " bitwidth of given value: " << type;
+                            << " bitwidth of given value: " << type;
   }
   return success();
 }
 
-static ParseResult parseVectorWriteOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseVectorWriteOp(OpAsmParser &parser,
+                                      OperationState &result) {
   OpAsmParser::OperandType value, base, index;
-  VectorType resultType; IntegerType indexType;
+  VectorType resultType;
+  IntegerType indexType;
   if (parser.parseOperand(value) || parser.parseComma() ||
-      parser.parseOperand(base) || parser.parseLSquare() || 
+      parser.parseOperand(base) || parser.parseLSquare() ||
       parser.parseOperand(index) || parser.parseRSquare() ||
-      parser.parseOptionalAttrDict(result.attributes) || 
-      parser.parseColon() || parser.parseType(resultType))
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(resultType))
     return failure();
 
   result.addTypes(resultType);
-  indexType = parser.getBuilder().getIntegerType(log2(resultType.getShape()[0]));
-  return parser.resolveOperands({value, base, index}, 
-                                {resultType.getElementType(), resultType, indexType},
-                                parser.getNameLoc(), result.operands);
+  indexType =
+      parser.getBuilder().getIntegerType(log2(resultType.getShape()[0]));
+  return parser.resolveOperands(
+      {value, base, index},
+      {resultType.getElementType(), resultType, indexType}, parser.getNameLoc(),
+      result.operands);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/Btor/BtorIRToBtorTranslation.cpp
+++ b/lib/Target/Btor/BtorIRToBtorTranslation.cpp
@@ -96,12 +96,11 @@ void Serialize::createSort(Type type) {
     setSortWithType(type, nextLine);
     m_output << nextLine << " sort bitvec " << bitWidth << '\n';
   } else {
-    assert (type.isa<VectorType>());
-    auto shape = type.cast<VectorType>().getShape().front();
-    auto elementType = type.cast<VectorType>().getElementType();
-    Type shapeType = IntegerType::get(type.getContext(), unsigned (log2(shape)));
-    assert (elementType.getIntOrFloatBitWidth() > 0);
-    assert (shapeType.getIntOrFloatBitWidth() > 0);
+    assert (type.isa<btor::ArrayType>());
+    auto shapeType = type.cast<btor::ArrayType>().getShape();
+    auto elementType = type.cast<btor::ArrayType>().getElement();
+    assert (elementType.getWidth() > 0);
+    assert (shapeType.getWidth() > 0);
 
     auto shapeSort = getOrCreateSort(shapeType);
     auto elementSort = getOrCreateSort(elementType);

--- a/lib/Target/Btor/BtorIRToBtorTranslation.cpp
+++ b/lib/Target/Btor/BtorIRToBtorTranslation.cpp
@@ -8,9 +8,9 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/Translation.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/ADT/TypeSwitch.h"
 
 #include <iostream>
 #include <string>
@@ -18,21 +18,18 @@
 using namespace mlir;
 using namespace mlir::btor;
 
-LogicalResult Serialize::buildTernaryOperation(const Value &first,
-                                              const Value &second,
-                                              const Value &third,
-                                              const Value &res,
-                                              const Type type,
-                                              std::string op) {
-  assert (opIsInCache(first));
-  assert (opIsInCache(second));
-  assert (opIsInCache(third));
+LogicalResult
+Serialize::buildTernaryOperation(const Value &first, const Value &second,
+                                 const Value &third, const Value &res,
+                                 const Type type, std::string op) {
+  assert(opIsInCache(first));
+  assert(opIsInCache(second));
+  assert(opIsInCache(third));
   auto sortId = getOrCreateSort(type);
 
   m_output << nextLine << " ";
-  m_output << op << " " << sortId << " " << getOpFromCache(first) 
-    << " " << getOpFromCache(second) << " "
-    << getOpFromCache(third) << '\n';
+  m_output << op << " " << sortId << " " << getOpFromCache(first) << " "
+           << getOpFromCache(second) << " " << getOpFromCache(third) << '\n';
 
   setCacheWithOp(res, nextLine);
   nextLine += 1;
@@ -41,16 +38,15 @@ LogicalResult Serialize::buildTernaryOperation(const Value &first,
 
 LogicalResult Serialize::buildBinaryOperation(const Value &lhs,
                                               const Value &rhs,
-                                              const Value &res,
-                                              const Type type,
+                                              const Value &res, const Type type,
                                               std::string op) {
-  assert (opIsInCache(lhs));
-  assert (opIsInCache(rhs));
+  assert(opIsInCache(lhs));
+  assert(opIsInCache(rhs));
   auto sortId = getOrCreateSort(type);
 
   m_output << nextLine << " ";
-  m_output << op << " " << sortId << " " << getOpFromCache(lhs) 
-    << " " << getOpFromCache(rhs) << '\n';
+  m_output << op << " " << sortId << " " << getOpFromCache(lhs) << " "
+           << getOpFromCache(rhs) << '\n';
 
   setCacheWithOp(res, nextLine);
   nextLine += 1;
@@ -58,14 +54,14 @@ LogicalResult Serialize::buildBinaryOperation(const Value &lhs,
 }
 
 LogicalResult Serialize::buildUnaryOperation(const Value &value,
-              const Value &res, const Type type, std::string op) {
-  assert (opIsInCache(value));
+                                             const Value &res, const Type type,
+                                             std::string op) {
+  assert(opIsInCache(value));
   auto sortId = getOrCreateSort(type);
 
   m_output << nextLine << " ";
   m_output << op << " ";
-  m_output << sortId 
-    << " " << getOpFromCache(value) << "\n";
+  m_output << sortId << " " << getOpFromCache(value) << "\n";
 
   setCacheWithOp(res, nextLine);
   nextLine += 1;
@@ -73,16 +69,17 @@ LogicalResult Serialize::buildUnaryOperation(const Value &value,
 }
 
 LogicalResult Serialize::buildCastOperation(const Value &value,
-              const Value &res, const Type type, std::string op) {
-  assert (opIsInCache(value));
+                                            const Value &res, const Type type,
+                                            std::string op) {
+  assert(opIsInCache(value));
   auto sortId = getOrCreateSort(type);
   auto opType = type.dyn_cast<btor::BitVecType>();
   auto valueType = value.getType().dyn_cast<btor::BitVecType>();
   auto width = opType.getWidth() - valueType.getWidth();
 
   m_output << nextLine << " ";
-  m_output << op << " " << sortId << " " 
-    << getOpFromCache(value) << " " << width << "\n";
+  m_output << op << " " << sortId << " " << getOpFromCache(value) << " "
+           << width << "\n";
 
   setCacheWithOp(res, nextLine);
   nextLine += 1;
@@ -92,21 +89,21 @@ LogicalResult Serialize::buildCastOperation(const Value &value,
 void Serialize::createSort(Type type) {
   if (type.isa<btor::BitVecType>()) {
     auto bitWidth = type.dyn_cast<btor::BitVecType>().getWidth();
-    assert (bitWidth > 0);
+    assert(bitWidth > 0);
     setSortWithType(type, nextLine);
     m_output << nextLine << " sort bitvec " << bitWidth << '\n';
   } else {
-    assert (type.isa<btor::ArrayType>());
+    assert(type.isa<btor::ArrayType>());
     auto shapeType = type.cast<btor::ArrayType>().getShape();
     auto elementType = type.cast<btor::ArrayType>().getElement();
-    assert (elementType.getWidth() > 0);
-    assert (shapeType.getWidth() > 0);
+    assert(elementType.getWidth() > 0);
+    assert(shapeType.getWidth() > 0);
 
     auto shapeSort = getOrCreateSort(shapeType);
     auto elementSort = getOrCreateSort(elementType);
     setSortWithType(type, nextLine);
-    m_output << nextLine << " sort array "
-      << shapeSort << " " << elementSort << '\n';
+    m_output << nextLine << " sort array " << shapeSort << " " << elementSort
+             << '\n';
   }
   nextLine += 1;
 }
@@ -126,22 +123,21 @@ LogicalResult Serialize::createBtorLine(btor::SExtOp &op, bool isInit) {
 }
 
 LogicalResult Serialize::createBtorLine(btor::SliceOp &op, bool isInit) {
-  assert (opIsInCache(op.lower_bound()));
-  assert (opIsInCache(op.upper_bound()));
-  assert (opIsInCache(op.in()));
+  assert(opIsInCache(op.lower_bound()));
+  assert(opIsInCache(op.upper_bound()));
+  assert(opIsInCache(op.in()));
   btor::ConstantOp lower = op.lower_bound().getDefiningOp<btor::ConstantOp>();
   btor::ConstantOp upper = op.upper_bound().getDefiningOp<btor::ConstantOp>();
-  assert (lower);
-  assert (upper);
+  assert(lower);
+  assert(upper);
   auto sortId = getOrCreateSort(op.getType());
 
-  m_output << nextLine << " slice " << sortId 
-    << " " << getOpFromCache(op.in()) << " "
-    << upper.value().getInt() << " "
-    << lower.value().getInt() << "\n"; 
+  m_output << nextLine << " slice " << sortId << " " << getOpFromCache(op.in())
+           << " " << upper.value().getInt() << " " << lower.value().getInt()
+           << "\n";
 
   setCacheWithOp(op.result(), nextLine);
-  nextLine += 1;  
+  nextLine += 1;
   return success();
 }
 
@@ -174,28 +170,29 @@ LogicalResult Serialize::createBtorLine(btor::RedAndOp &op, bool isInit) {
 }
 
 LogicalResult Serialize::createBtorLine(btor::IffOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "iff");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "iff");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ImpliesOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "implies");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "implies");
 }
 
 LogicalResult Serialize::createBtorLine(btor::CmpOp &op, bool isInit) {
-  assert (opIsInCache(op.lhs()));
-  assert (opIsInCache(op.rhs()));
+  assert(opIsInCache(op.lhs()));
+  assert(opIsInCache(op.rhs()));
   auto sortId = getOrCreateSort(op.getType());
-  
+
   m_output << nextLine;
-  switch (op.predicate())
-  {
+  switch (op.predicate()) {
   case BtorPredicate::eq:
     m_output << " eq ";
     break;
   case BtorPredicate::ne:
     m_output << " neq ";
     break;
-  case BtorPredicate::sge: 
+  case BtorPredicate::sge:
     m_output << " sgte ";
     break;
   case BtorPredicate::sgt:
@@ -220,9 +217,8 @@ LogicalResult Serialize::createBtorLine(btor::CmpOp &op, bool isInit) {
     m_output << " ult ";
     break;
   }
-  m_output << sortId
-    << " " << getOpFromCache(op.lhs()) << " "
-    << getOpFromCache(op.rhs()) << '\n';
+  m_output << sortId << " " << getOpFromCache(op.lhs()) << " "
+           << getOpFromCache(op.rhs()) << '\n';
 
   setCacheWithOp(op.getResult(), nextLine);
   nextLine += 1;
@@ -230,116 +226,144 @@ LogicalResult Serialize::createBtorLine(btor::CmpOp &op, bool isInit) {
 }
 
 LogicalResult Serialize::createBtorLine(btor::AndOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "and");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "and");
 }
 
 LogicalResult Serialize::createBtorLine(btor::NandOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "nand");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "nand");
 }
 
 LogicalResult Serialize::createBtorLine(btor::NorOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "nor");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "nor");
 }
 
 LogicalResult Serialize::createBtorLine(btor::OrOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "or");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "or");
 }
 
 LogicalResult Serialize::createBtorLine(btor::XnorOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "xnor");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "xnor");
 }
 
 LogicalResult Serialize::createBtorLine(btor::XOrOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "xor");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "xor");
 }
 
 LogicalResult Serialize::createBtorLine(btor::RotateROp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "ror");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "ror");
 }
 
 LogicalResult Serialize::createBtorLine(btor::RotateLOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "rol");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "rol");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ShiftLLOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "sll");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "sll");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ShiftRAOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "sra");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "sra");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ShiftRLOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "srl");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "srl");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ConcatOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "concat");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "concat");
 }
 
 LogicalResult Serialize::createBtorLine(btor::AddOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "add");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "add");
 }
 
 LogicalResult Serialize::createBtorLine(btor::MulOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "mul");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "mul");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SDivOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "sdiv");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "sdiv");
 }
 
-LogicalResult Serialize::createBtorLine(btor::UDivOp &op, bool isInit) { 
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "udiv");
+LogicalResult Serialize::createBtorLine(btor::UDivOp &op, bool isInit) {
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "udiv");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SModOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "smod");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "smod");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SRemOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "srem");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "srem");
 }
 
 LogicalResult Serialize::createBtorLine(btor::URemOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "urem");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "urem");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SubOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "sub");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "sub");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SAddOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "saddo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "saddo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::UAddOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "uaddo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "uaddo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SDivOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "sdivo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "sdivo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SMulOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "smulo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "smulo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::UMulOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "umulo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "umulo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::SSubOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "ssubo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "ssubo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::USubOverflowOp &op, bool isInit) {
-  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(), "usubo");
+  return buildBinaryOperation(op.lhs(), op.rhs(), op.result(), op.getType(),
+                              "usubo");
 }
 
 LogicalResult Serialize::createBtorLine(btor::IteOp &op, bool isInit) {
-  return buildTernaryOperation(op.condition(), op.true_value(), 
-    op.false_value(), op.result(), op.getType(), "ite");
+  return buildTernaryOperation(op.condition(), op.true_value(),
+                               op.false_value(), op.result(), op.getType(),
+                               "ite");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ArrayOp &op, bool isInit) {
@@ -347,35 +371,34 @@ LogicalResult Serialize::createBtorLine(btor::ArrayOp &op, bool isInit) {
 }
 
 LogicalResult Serialize::createBtorLine(btor::InitArrayOp &op, bool isInit) {
-  assert (opIsInCache(op.init()));
+  assert(opIsInCache(op.init()));
   setCacheWithOp(op.result(), getOpFromCache(op.init()));
   return success();
 }
 
 LogicalResult Serialize::createBtorLine(btor::ReadOp &op, bool isInit) {
-  return buildBinaryOperation(op.base(), op.index(), op.result(), op.getType(), "read");
+  return buildBinaryOperation(op.base(), op.index(), op.result(), op.getType(),
+                              "read");
 }
 
 LogicalResult Serialize::createBtorLine(btor::WriteOp &op, bool isInit) {
-  return buildTernaryOperation(op.base(), op.index(), 
-    op.value(), op.result(), op.getType(), "write");
+  return buildTernaryOperation(op.base(), op.index(), op.value(), op.result(),
+                               op.getType(), "write");
 }
 
 LogicalResult Serialize::createBtorLine(btor::ConstraintOp &op, bool isInit) {
-  assert (opIsInCache(op.constraint()));
+  assert(opIsInCache(op.constraint()));
 
-  m_output << nextLine << " constraint " 
-    << getOpFromCache(op.constraint()) << '\n';
+  m_output << nextLine << " constraint " << getOpFromCache(op.constraint())
+           << '\n';
   nextLine += 1;
   return success();
 }
 
-
 LogicalResult Serialize::createBtorLine(btor::ConstantOp &op, bool isInit) {
   auto sortId = getOrCreateSort(op.getType());
-  m_output << nextLine << " constd " 
-    << sortId << " "
-    << op.value().getInt() << '\n';
+  m_output << nextLine << " constd " << sortId << " " << op.value().getInt()
+           << '\n';
 
   setCacheWithOp(op.getResult(), nextLine);
   nextLine += 1;
@@ -392,7 +415,7 @@ LogicalResult Serialize::createBtorLine(btor::InputOp &op, bool isInit) {
 }
 
 LogicalResult Serialize::createBtorLine(btor::AssertNotOp &op, bool isInit) {
-  assert (opIsInCache(op.arg()));
+  assert(opIsInCache(op.arg()));
 
   m_output << nextLine << " bad " << getOpFromCache(op.arg()) << '\n';
   nextLine += 1;
@@ -433,13 +456,16 @@ LogicalResult Serialize::createBtorLine(mlir::BranchOp &op, bool isInit) {
     auto sortId = getOrCreateSort(res.getType());
     if (opIsInCache(res)) {
       auto opNextState = getOpFromCache(res);
-      if ((opNextState == m_states.at(i)) && isInit) { continue; }
+      if ((opNextState == m_states.at(i)) && isInit) {
+        continue;
+      }
       m_output << nextLine;
-      if (isInit) { m_output << " init "; } 
-      else {  m_output << " next "; }
-      m_output << sortId
-        << " " << m_states.at(i) << " " 
-        << opNextState << "\n";
+      if (isInit) {
+        m_output << " init ";
+      } else {
+        m_output << " next ";
+      }
+      m_output << sortId << " " << m_states.at(i) << " " << opNextState << "\n";
       nextLine += 1;
     }
   }
@@ -450,16 +476,18 @@ LogicalResult Serialize::createBtorLine(mlir::BranchOp &op, bool isInit) {
     Value res = op.getOperand(i);
     if (opIsInCache(res)) {
       continue;
-    } 
+    }
     auto sortId = getOrCreateSort(res.getType());
     auto resCode = hash_value(res);
     if (trackCopiedStates.count(resCode) != 0) {
       m_output << nextLine;
-      if (isInit) { m_output << " init "; } 
-      else {  m_output << " next "; }
-      m_output << sortId
-        << " " << m_states.at(i) << " " 
-        << trackCopiedStates.at(resCode) << "\n";
+      if (isInit) {
+        m_output << " init ";
+      } else {
+        m_output << " next ";
+      }
+      m_output << sortId << " " << m_states.at(i) << " "
+               << trackCopiedStates.at(resCode) << "\n";
       nextLine += 1;
     } else {
       trackCopiedStates[resCode] = m_states.at(i);
@@ -468,28 +496,28 @@ LogicalResult Serialize::createBtorLine(mlir::BranchOp &op, bool isInit) {
   return success();
 }
 
-LogicalResult Serialize::Serialize::createBtor(mlir::Operation &op, bool isInit) {
+LogicalResult Serialize::Serialize::createBtor(mlir::Operation &op,
+                                               bool isInit) {
   LogicalResult status =
       llvm::TypeSwitch<Operation *, LogicalResult>(&op)
           // btor ops.
-          .Case<btor::UExtOp, btor::SExtOp, btor::SliceOp,
-                btor::NotOp, btor::IncOp, btor::DecOp, btor::NegOp,
-                btor::RedAndOp, btor::RedXorOp, btor::RedOrOp, btor::InputOp,
-                btor::AssertNotOp, btor::ConstantOp, btor::NDStateOp,
-                btor::IffOp, btor::ImpliesOp, btor::CmpOp,
-                btor::AndOp, btor::NandOp, btor::NorOp, btor::OrOp,
+          .Case<btor::UExtOp, btor::SExtOp, btor::SliceOp, btor::NotOp,
+                btor::IncOp, btor::DecOp, btor::NegOp, btor::RedAndOp,
+                btor::RedXorOp, btor::RedOrOp, btor::InputOp, btor::AssertNotOp,
+                btor::ConstantOp, btor::NDStateOp, btor::IffOp, btor::ImpliesOp,
+                btor::CmpOp, btor::AndOp, btor::NandOp, btor::NorOp, btor::OrOp,
                 btor::XnorOp, btor::XOrOp, btor::RotateLOp, btor::RotateROp,
-                btor::ShiftLLOp, btor::ShiftRAOp, btor::ShiftRLOp, btor::ConcatOp,
-                btor::AddOp, btor::MulOp, btor::SDivOp, btor::UDivOp,
-                btor::SModOp, btor::SRemOp, btor::URemOp, btor::SubOp,
-                btor::SAddOverflowOp, btor::UAddOverflowOp, btor::SDivOverflowOp,
-                btor::SMulOverflowOp, btor::UMulOverflowOp, btor::InitArrayOp,
-                btor::SSubOverflowOp, btor::USubOverflowOp, btor::ReadOp,
-                btor::IteOp, btor::ArrayOp, btor::ConstraintOp, btor::WriteOp>(
+                btor::ShiftLLOp, btor::ShiftRAOp, btor::ShiftRLOp,
+                btor::ConcatOp, btor::AddOp, btor::MulOp, btor::SDivOp,
+                btor::UDivOp, btor::SModOp, btor::SRemOp, btor::URemOp,
+                btor::SubOp, btor::SAddOverflowOp, btor::UAddOverflowOp,
+                btor::SDivOverflowOp, btor::SMulOverflowOp,
+                btor::UMulOverflowOp, btor::InitArrayOp, btor::SSubOverflowOp,
+                btor::USubOverflowOp, btor::ReadOp, btor::IteOp, btor::ArrayOp,
+                btor::ConstraintOp, btor::WriteOp>(
               [&](auto op) { return createBtorLine(op, isInit); })
           // Standard ops.
-          .Case<BranchOp>(
-              [&](auto op) { return createBtorLine(op, isInit); })
+          .Case<BranchOp>([&](auto op) { return createBtorLine(op, isInit); })
           .Default([&](Operation *) {
             return op.emitOpError("unable to find printer for op");
           });
@@ -529,7 +557,7 @@ LogicalResult Serialize::translateMainFunction() {
   auto &funcOp = blocks.front().getOperations().front();
   // translate each block
   auto &regions = funcOp.getRegion(0);
-  assert (regions.getBlocks().size() == 2);
+  assert(regions.getBlocks().size() == 2);
   if (translateInitFunction(regions.getBlocks().front()).failed())
     return failure();
   if (translateNextFunction(regions.getBlocks().back()).failed())
@@ -557,7 +585,7 @@ namespace mlir {
 namespace btor {
 void registerToBtorTranslation() {
   TranslateFromMLIRRegistration toBtor(
-      "export-btor", 
+      "export-btor",
       [](ModuleOp module, raw_ostream &output) {
         return serializeModule(module, output);
       },

--- a/lib/Target/Btor/BtorToBtorIRTranslation.cpp
+++ b/lib/Target/Btor/BtorToBtorIRTranslation.cpp
@@ -17,7 +17,9 @@
 using namespace mlir;
 using namespace mlir::btor;
 
-std::pair <int,int> Deserialize::parseModelLine(Btor2Line *l, std::pair <int,int> numberedCommands) {
+std::pair<int, int>
+Deserialize::parseModelLine(Btor2Line *l,
+                            std::pair<int, int> numberedCommands) {
   setLineWithId(l->id, l);
   switch (l->tag) {
   case BTOR2_TAG_bad:
@@ -45,12 +47,12 @@ std::pair <int,int> Deserialize::parseModelLine(Btor2Line *l, std::pair <int,int
   case BTOR2_TAG_sort:
     m_sorts[l->id] = l;
     break;
-  
+
   case BTOR2_TAG_input:
     m_inputs[l->lineno] = numberedCommands.first;
     numberedCommands.first = numberedCommands.first + 1;
     break;
-  
+
   default:
     break;
   }
@@ -66,12 +68,12 @@ bool Deserialize::parseModelIsSuccessful() {
     return false;
   }
   // register each line that has been parsed
-  auto numLines = btor2parser_max_id (m_model);
+  auto numLines = btor2parser_max_id(m_model);
   m_lines.resize(numLines + 1, nullptr);
   Btor2LineIterator it = btor2parser_iter_init(m_model);
   Btor2Line *line;
   // (inputNumber, badPropertyNumber)
-  std::pair <int,int> numberedCommands (0,0);
+  std::pair<int, int> numberedCommands(0, 0);
   while ((line = btor2parser_iter_next(&it))) {
     numberedCommands = parseModelLine(line, numberedCommands);
   }
@@ -80,64 +82,64 @@ bool Deserialize::parseModelIsSuccessful() {
 }
 
 ///===----------------------------------------------------------------------===//
-/// This function's goal is to create the MLIR Operation that corresponds to 
-/// the given Btor2Line*, cur, into the basic block designated by the class 
-/// field m_builder. Make sure that the kids have already been created before 
+/// This function's goal is to create the MLIR Operation that corresponds to
+/// the given Btor2Line*, cur, into the basic block designated by the class
+/// field m_builder. Make sure that the kids have already been created before
 /// calling this method
 ///
 /// e.x:
 ///     Operation * res = createMLIR(cur, cur->args);
 ///
 ///===----------------------------------------------------------------------===//
-Operation * Deserialize::createMLIR(const Btor2Line *line, 
-                                const SmallVector<Value> &kids,
-                                const SmallVector<unsigned> &arguments) {
+Operation *Deserialize::createMLIR(const Btor2Line *line,
+                                   const SmallVector<Value> &kids,
+                                   const SmallVector<unsigned> &arguments) {
   Operation *res = nullptr;
   auto lineId = line->lineno;
 
   switch (line->tag) {
   // binary ops
   case BTOR2_TAG_slt:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::slt, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::slt, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_slte:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::sle, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::sle, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_sgt:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::sgt, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::sgt, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_sgte:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::sge, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::sge, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_neq:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ne, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ne, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_eq:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::eq, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::eq, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_ugt:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ugt, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ugt, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_ugte:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::uge, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::uge, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_ult:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ult, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ult, kids[0],
+                                         kids[1], lineId);
     break;
   case BTOR2_TAG_ulte:
-    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ule, 
-                                        kids[0], kids[1], lineId);
+    res = buildComparisonOp<btor::CmpOp>(btor::BtorPredicate::ule, kids[0],
+                                         kids[1], lineId);
     break;
-  
+
   case BTOR2_TAG_concat:
     res = buildConcatOp(kids[0], kids[1], lineId);
     break;
@@ -252,28 +254,28 @@ Operation * Deserialize::createMLIR(const Btor2Line *line,
     res = buildReductionOp<btor::RedXorOp>(kids[0], lineId);
     break;
   case BTOR2_TAG_const:
-    res = buildConstantOp(line->sort.bitvec.width,
-                        std::string(line->constant), 2, lineId);
+    res = buildConstantOp(line->sort.bitvec.width, std::string(line->constant),
+                          2, lineId);
     break;
   case BTOR2_TAG_constd:
-    res = buildConstantOp(line->sort.bitvec.width, 
-                        std::string(line->constant), 10, lineId);
+    res = buildConstantOp(line->sort.bitvec.width, std::string(line->constant),
+                          10, lineId);
     break;
   case BTOR2_TAG_consth:
-    res = buildConstantOp(line->sort.bitvec.width, 
-                        std::string(line->constant), 16, lineId);
+    res = buildConstantOp(line->sort.bitvec.width, std::string(line->constant),
+                          16, lineId);
     break;
   case BTOR2_TAG_one:
-    res = buildConstantOp(line->sort.bitvec.width, 
-                        std::string("one"), 10, lineId);
+    res = buildConstantOp(line->sort.bitvec.width, std::string("one"), 10,
+                          lineId);
     break;
   case BTOR2_TAG_ones:
-    res = buildConstantOp(line->sort.bitvec.width,
-                        std::string("ones"), 10, lineId);
+    res = buildConstantOp(line->sort.bitvec.width, std::string("ones"), 10,
+                          lineId);
     break;
   case BTOR2_TAG_zero:
-    res = buildConstantOp(line->sort.bitvec.width, 
-                        std::string("zero"), 10, lineId);
+    res = buildConstantOp(line->sort.bitvec.width, std::string("zero"), 10,
+                          lineId);
     break;
   case BTOR2_TAG_input:
     res = buildInputOp(line->sort.bitvec.width, lineId);
@@ -281,7 +283,6 @@ Operation * Deserialize::createMLIR(const Btor2Line *line,
   case BTOR2_TAG_constraint:
     res = buildUnaryOp<btor::ConstraintOp>(kids[0], lineId);
     break;
-
 
   // indexed ops
   case BTOR2_TAG_slice:
@@ -310,7 +311,7 @@ Operation * Deserialize::createMLIR(const Btor2Line *line,
 
   // state ops
   case BTOR2_TAG_state:
-      res = buildNDStateOp(line, lineId);
+    res = buildNDStateOp(line, lineId);
     break;
 
   case BTOR2_TAG_init:
@@ -330,14 +331,13 @@ Operation * Deserialize::createMLIR(const Btor2Line *line,
 ///===----------------------------------------------------------------------===//
 /// Some Btor lines may refer to a negated version of a prior line. This
 /// function creates a negated version of the original line, and stores it in
-/// the cache, only after the caller ensures that the original line has been 
+/// the cache, only after the caller ensures that the original line has been
 /// created and saved in the cache
 ///===----------------------------------------------------------------------===//
-void Deserialize::createNegateLine(int64_t negativeLine,
-                                  const unsigned lineId,
-                                  const Value &child) {
+void Deserialize::createNegateLine(int64_t negativeLine, const unsigned lineId,
+                                   const Value &child) {
   auto res = buildUnaryOp<btor::NotOp>(getFromCacheById(std::abs(negativeLine)),
-                                      lineId);
+                                       lineId);
   assert(res);
   assert(res->getNumResults() == 1);
   setCacheWithId(negativeLine, res->getResult(0));
@@ -346,7 +346,7 @@ void Deserialize::createNegateLine(int64_t negativeLine,
 ///===----------------------------------------------------------------------===//
 /// This method determines if a Btor2Line has a return value
 ///===----------------------------------------------------------------------===//
-bool Deserialize::hasReturnValue(Btor2Line * line) {
+bool Deserialize::hasReturnValue(Btor2Line *line) {
   bool hasReturnValue = true;
   switch (line->tag) {
   case BTOR2_TAG_constraint:
@@ -369,10 +369,12 @@ bool Deserialize::hasReturnValue(Btor2Line * line) {
 /// This method determines if we are dealing with the state argument of
 ///   a Btor2 init operation
 ///===----------------------------------------------------------------------===//
-bool Deserialize::isStateArgumentOfInitOp(Btor2Line * cur, unsigned idx) {
+bool Deserialize::isStateArgumentOfInitOp(Btor2Line *cur, unsigned idx) {
   if (BTOR2_TAG_init == cur->tag) {
     auto argumentId = cur->args[idx];
-    if (argumentId < 0) { argumentId = std::abs(argumentId); }
+    if (argumentId < 0) {
+      argumentId = std::abs(argumentId);
+    }
     return BTOR2_TAG_state == getLineById(argumentId)->tag;
   }
   return false;
@@ -382,7 +384,7 @@ bool Deserialize::isStateArgumentOfInitOp(Btor2Line * cur, unsigned idx) {
 /// We use this method to check if a line needs to have a corresponding MLIR
 /// operation created
 ///===----------------------------------------------------------------------===//
-bool Deserialize::needsMLIROp(Btor2Line * line) {
+bool Deserialize::needsMLIROp(Btor2Line *line) {
   bool isValid = true;
   switch (line->tag) {
   case BTOR2_TAG_next:
@@ -399,10 +401,10 @@ bool Deserialize::needsMLIROp(Btor2Line * line) {
 }
 
 ///===----------------------------------------------------------------------===//
-/// This function's goal is to add the MLIR Operation that corresponds to 
-/// the given Btor2Line* into the basic block designated by the class field 
+/// This function's goal is to add the MLIR Operation that corresponds to
+/// the given Btor2Line* into the basic block designated by the class field
 /// m_builder. Then, the MLIR Value of the newly minted operation is added
-/// into our cache for future reference within the basic block. 
+/// into our cache for future reference within the basic block.
 ///
 /// e.x:
 ///      for (next : m_nexts) {
@@ -434,16 +436,18 @@ void Deserialize::toOp(Btor2Line *line) {
         if (arg_i < 0) {
           // if original operation is cached, negate it on the fly
           if (valueAtIdIsInCache(std::abs(arg_i))) {
-            createNegateLine(arg_i, cur->lineno, getFromCacheById(std::abs(arg_i))); 
+            createNegateLine(arg_i, cur->lineno,
+                             getFromCacheById(std::abs(arg_i)));
           } else {
             todo.push_back(getLineById(std::abs(arg_i)));
           }
-        } else if (isStateArgumentOfInitOp(cur, i)){
-          // make sure that we check for the case that the state has an initialization!
+        } else if (isStateArgumentOfInitOp(cur, i)) {
+          // make sure that we check for the case that the state has an
+          // initialization!
           if (auto initLine = getLineById(arg_i)->init) {
             continue;
           }
-            todo.push_back(getLineById(arg_i));
+          todo.push_back(getLineById(arg_i));
         } else {
           todo.push_back(getLineById(arg_i));
         }
@@ -463,29 +467,30 @@ void Deserialize::toOp(Btor2Line *line) {
     SmallVector<unsigned> arguments;
     if (cur->tag != BTOR2_TAG_slice) {
       for (unsigned i = 0; i < cur->nargs; ++i) {
-          if (isStateArgumentOfInitOp(cur, i)) {
-              kids.push_back(nullptr);
-              continue;
-          }
-          kids.push_back(getFromCacheById(cur->args[i]));
+        if (isStateArgumentOfInitOp(cur, i)) {
+          kids.push_back(nullptr);
+          continue;
+        }
+        kids.push_back(getFromCacheById(cur->args[i]));
       }
     } else {
-        kids.push_back(getFromCacheById(cur->args[0]));
-        arguments.push_back(cur->args[1]);
-        arguments.push_back(cur->args[2]);
+      kids.push_back(getFromCacheById(cur->args[0]));
+      arguments.push_back(cur->args[1]);
+      arguments.push_back(cur->args[2]);
     }
     res = createMLIR(cur, kids, arguments);
-    // We never have to use the result of a btor line with no 
+    // We never have to use the result of a btor line with no
     // return values since btor2 doesn't allow it
     if (hasReturnValue(getLineById(cur->id))) {
-      assert (res);
+      assert(res);
       setCacheWithId(cur->id, res);
-    } 
+    }
     todo.pop_back();
   }
 }
 
-std::vector<Value> Deserialize::collectReturnValuesForInit(const std::vector<Type> &returnTypes) {
+std::vector<Value>
+Deserialize::collectReturnValuesForInit(const std::vector<Type> &returnTypes) {
   std::vector<Value> results(m_states.size(), nullptr);
   for (unsigned i = 0; i < m_states.size(); ++i) {
     results[i] = getFromCacheById(m_states.at(i)->id);
@@ -493,11 +498,12 @@ std::vector<Value> Deserialize::collectReturnValuesForInit(const std::vector<Typ
   return results;
 }
 
-std::vector<Value> Deserialize::buildInitFunction(const std::vector<Type> &returnTypes) {
+std::vector<Value>
+Deserialize::buildInitFunction(const std::vector<Type> &returnTypes) {
   // clear cache so that values are mapped to the right Basic Block
   m_cache.clear();
-  // We need to make sure that states are initialized in order of 
-  // appearance to avoid using a nd value when an initialization 
+  // We need to make sure that states are initialized in order of
+  // appearance to avoid using a nd value when an initialization
   // exists later in the btor file
   for (auto state : m_states) {
     if (int64_t initLine = state->init) {
@@ -510,8 +516,9 @@ std::vector<Value> Deserialize::buildInitFunction(const std::vector<Type> &retur
   return collectReturnValuesForInit(returnTypes);
 }
 
-std::vector<Value> Deserialize::buildNextFunction(
-    const std::vector<Type> &returnTypes, Block *body) {
+std::vector<Value>
+Deserialize::buildNextFunction(const std::vector<Type> &returnTypes,
+                               Block *body) {
   // clear cache so that values are mapped to the right Basic Block
   m_cache.clear();
   // initialize states with block arguments
@@ -521,24 +528,29 @@ std::vector<Value> Deserialize::buildNextFunction(
   }
 
   // start with nexts, then add constraints & bads, for logic sharing
-  for (auto next : m_nexts) { toOp(next); }
-  for (auto constraint : m_constraints) { toOp(constraint); }
-  for (auto bad : m_bads) { toOp(bad); }
+  for (auto next : m_nexts) {
+    toOp(next);
+  }
+  for (auto constraint : m_constraints) {
+    toOp(constraint);
+  }
+  for (auto bad : m_bads) {
+    toOp(bad);
+  }
 
   // close with a fitting returnOp
   std::vector<Value> results(m_states.size(), nullptr);
   for (unsigned i = 0; i < m_states.size(); ++i) {
     int64_t nextState = m_states.at(i)->next;
-    if (nextState == 0) { 
+    if (nextState == 0) {
       if (m_states.at(i)->init != 0) {
         results[i] = getFromCacheById(m_states.at(i)->id);
         continue;
       }
       auto stateType = getFromCacheById(m_states.at(i)->id).getType();
       auto res = m_builder.create<btor::NDStateOp>(
-        FileLineColLoc::get(m_sourceFile, m_states.at(i)->lineno, 0), 
-        stateType,
-        m_builder.getIntegerAttr(m_builder.getIntegerType(64), i));
+          FileLineColLoc::get(m_sourceFile, m_states.at(i)->lineno, 0),
+          stateType, m_builder.getIntegerAttr(m_builder.getIntegerType(64), i));
       assert(res);
       assert(res->getNumResults() == 1);
       results[i] = res->getResult(0);
@@ -559,8 +571,7 @@ OwningOpRef<FuncOp> Deserialize::buildMainFunction() {
   }
   // create main function
   OperationState state(m_unknownLoc, FuncOp::getOperationName());
-  FuncOp::build(m_builder, state, "main",
-                FunctionType::get(m_context, {}, {}));
+  FuncOp::build(m_builder, state, "main", FunctionType::get(m_context, {}, {}));
   OwningOpRef<FuncOp> funcOp = cast<FuncOp>(Operation::create(state));
   Region &region = funcOp->getBody();
   OpBuilder::InsertionGuard guard(m_builder);
@@ -571,7 +582,8 @@ OwningOpRef<FuncOp> Deserialize::buildMainFunction() {
   auto opPosition = m_builder.getInsertionPoint();
   // Create infinite loop that inlines next function
   std::vector<Location> returnLocs(m_states.size(), funcOp->getLoc());
-  Block *loopBlock = m_builder.createBlock(body->getParent(), {}, {returnTypes}, {returnLocs});
+  Block *loopBlock =
+      m_builder.createBlock(body->getParent(), {}, {returnTypes}, {returnLocs});
   auto nextResults = buildNextFunction(returnTypes, loopBlock);
   m_builder.create<BranchOp>(m_unknownLoc, loopBlock, nextResults);
   // add call to branch from original basic block
@@ -582,7 +594,7 @@ OwningOpRef<FuncOp> Deserialize::buildMainFunction() {
 }
 
 static OwningOpRef<ModuleOp> deserializeModule(const llvm::MemoryBuffer *input,
-                                         MLIRContext *context) {
+                                               MLIRContext *context) {
   context->loadDialect<btor::BtorDialect, StandardOpsDialect>();
 
   OwningOpRef<ModuleOp> owningModule(ModuleOp::create(FileLineColLoc::get(


### PR DESCRIPTION
Given the circuit below: 
```
1 sort bitvec 4
2 sort array 1 1
3 one 1
4 constd 1 8
5 state 2
6 init 2 5 3
7 read 1 5 4
8 one 1
9 add 1 7 8
10 write 2 5 4 9
11 next 2 5 10
12 ones 1
13 sort bitvec 1
14 eq 13 7 12
15 bad 14
```

We can now generate the equivalent program in Btor Dialect:
```
module {
  func @main() {
    %0 = btor.constant 1 : i4 !btor.bv<4>
    %1 = btor.array %0 : !btor.array<<4>, <4>>
    br ^bb1(%1 : !btor.array<<4>, <4>>)
  ^bb1(%2: !btor.array<<4>, <4>>):  // 2 preds: ^bb0, ^bb1
    %3 = btor.constant 1 : i4 !btor.bv<4>
    %4 = btor.constant -8 : i4 !btor.bv<4>
    %5 = btor.read %2[%4] : !btor.array<<4>, <4>>, !btor.bv<4>
    %6 = btor.add %5, %3 : !btor.bv<4>
    %7 = btor.write %6, %2[%4] : !btor.array<<4>, <4>>
    %8 = btor.constant -1 : i4 !btor.bv<4>
    %9 = btor.cmp eq, %5, %8 : !btor.bv<4>
    btor.assert_not(%9), 0 : i64 !btor.bv<1>
    br ^bb1(%7 : !btor.array<<4>, <4>>)
  }
}
```

And the final llvm ir is as expected:

```
declare void @__VERIFIER_error()
declare void @__VERIFIER_assert(i1, i64)
define void @main() !dbg !3 {
  br label %1, !dbg !7
1:                                                ; preds = %8, %0
  %2 = phi <16 x i4> [ %5, %8 ], [ <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>, %0 ]
  %3 = extractelement <16 x i4> %2, i4 -8, !dbg !9
  %4 = add i4 %3, 1, !dbg !10
  %5 = insertelement <16 x i4> %2, i4 %4, i4 -8, !dbg !11
  %6 = icmp eq i4 %3, -1, !dbg !12
  %7 = xor i1 %6, true, !dbg !13
  br i1 %7, label %8, label %9, !dbg !14
8:                                                ; preds = %1
  br label %1, !dbg !15
9:                                                ; preds = %1
  call void @__VERIFIER_assert(i1 %7, i64 0), !dbg !16
  call void @__VERIFIER_error(), !dbg !17
  unreachable, !dbg !18
}
```