### PR TITLE
feat: add inlining interface for btor dialect

### DIFF
--- a/lib/Dialect/Btor/IR/BtorDialect.cpp
+++ b/lib/Dialect/Btor/IR/BtorDialect.cpp
@@ -8,11 +8,51 @@
 
 #include "Dialect/Btor/IR/Btor.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/Parser.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 using namespace mlir;
 using namespace mlir::btor;
 
 #include "Dialect/Btor/IR/BtorOpsDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// BtorDialect Interfaces
+//===----------------------------------------------------------------------===//
+namespace {
+/// This class defines the interface for handling inlining with btor ops
+struct BtorInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+  ~BtorInlinerInterface() override = default;
+
+  /// All call operations within BtorDialect can be inlined.
+  bool isLegalToInline(Operation *call, Operation *callable,
+                       bool wouldBeCloned) const final {
+    return true;
+  }
+
+  /// Returns true if the given region 'src' can be inlined into the region
+  /// 'dest' that is attached to an operation registered to the current dialect.
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       BlockAndValueMapping &) const final {
+    // Return true here when inlining into std func operation
+    auto *op = dest->getParentOp();
+    return isa<mlir::FuncOp>(op);
+  }
+
+  /// Returns true if the given operation 'op', that is registered to this
+  /// dialect, can be inlined into the region 'dest' that is attached to an
+  /// operation registered to the current dialect.
+  bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
+                       BlockAndValueMapping &) const final {
+    return true;
+  }
+
+  /// BtorDialect terminator operations don't really need any special handing.
+  void handleTerminator(Operation *op, Block *newDest) const final {}
+};
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Btor dialect.
@@ -25,4 +65,5 @@ void BtorDialect::initialize() {
 #define GET_OP_LIST
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"
       >();
+  addInterfaces<BtorInlinerInterface>();
 }


### PR DESCRIPTION
Given the file below:
```
module {
  func @foo() -> (!btor.bv<3>) {
    // %0 = arith.constant 42 : i32
    // %0 = btor.constant -3 : i3 !btor.bv<3>
    %2 = btor.constant -3 : i3 !btor.bv<3>
    %3 = btor.constant 0 : i3 !btor.bv<3>
    %4 = btor.ror %2, %3 : !btor.bv<3>
    return %4 : !btor.bv<3>
  }
  func @main() {
    %0 = btor.constant -3 : i3 !btor.bv<3>
    br ^bb1(%0 : !btor.bv<3>)
  ^bb1(%1: !btor.bv<3>):  // 2 preds: ^bb0, ^bb1
    %2 = call @foo() : () -> !btor.bv<3>
    %3 = btor.constant 0 : i3 !btor.bv<3>
    %4 = btor.ror %2, %3 : !btor.bv<3>
    %5 = btor.cmp ne, %4, %2 : !btor.bv<3>
    btor.assert_not(%5), 0 : i64 !btor.bv<1>
    %6 = btor.constant 1 : i3 !btor.bv<3>
    %7 = btor.uaddo %1, %6 : !btor.bv<3>
    btor.assert_not(%7), 1 : i64 !btor.bv<1>
    br ^bb1(%1 : !btor.bv<3>)
  }
}
```

we can now inline the function call at `%2` using `btor2mlir-opt <file> --inline` to get:
```
module {
  func @foo() -> !btor.bv<3> {
    %0 = btor.constant -3 : i3 !btor.bv<3>
    %1 = btor.constant 0 : i3 !btor.bv<3>
    %2 = btor.ror %0, %1 : !btor.bv<3>
    return %2 : !btor.bv<3>
  }
  func @main() {
    %0 = btor.constant -3 : i3 !btor.bv<3>
    br ^bb1(%0 : !btor.bv<3>)
  ^bb1(%1: !btor.bv<3>):  // 2 preds: ^bb0, ^bb1
    %2 = btor.constant -3 : i3 !btor.bv<3>
    %3 = btor.constant 0 : i3 !btor.bv<3>
    %4 = btor.ror %2, %3 : !btor.bv<3>
    %5 = btor.constant 0 : i3 !btor.bv<3>
    %6 = btor.ror %4, %5 : !btor.bv<3>
    %7 = btor.cmp ne, %6, %4 : !btor.bv<3>
    btor.assert_not(%7), 0 : i64 !btor.bv<1>
    %8 = btor.constant 1 : i3 !btor.bv<3>
    %9 = btor.uaddo %1, %8 : !btor.bv<3>
    btor.assert_not(%9), 1 : i64 !btor.bv<1>
    br ^bb1(%1 : !btor.bv<3>)
  }
}
```