### PR TITLE
Liveness Analysis for btor.write

### DIFF
--- a/lib/Conversion/BtorToVector/BtorToVector.cpp
+++ b/lib/Conversion/BtorToVector/BtorToVector.cpp
@@ -62,15 +62,10 @@ struct WriteOpLowering : public ConvertOpToLLVMPattern<mlir::btor::WriteOp> {
   LogicalResult
   matchAndRewrite(mlir::btor::WriteOp writeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (resultIsLiveAfter(writeOp).succeeded()) {
-      rewriter.replaceOpWithNewOp<mlir::btor::WriteInPlaceOp>(
-          writeOp, writeOp.getType(), adaptor.value(), adaptor.base(),
-          adaptor.index());
-      return success();
-    }
-    auto resType = typeConverter->convertType(writeOp.result().getType());
-    rewriter.replaceOpWithNewOp<mlir::btor::VectorWriteOp>(
-        writeOp, resType, adaptor.value(), adaptor.base(), adaptor.index());
+    /// we are working under the assumption that all patterns are
+    /// identified by the liveness analysis
+    assert(writeOp.use_empty() && "include the liveness analysis pass");
+    writeOp.erase();
     return success();
   }
 };

--- a/lib/Dialect/Btor/Transforms/BtorLiveness.cpp
+++ b/lib/Dialect/Btor/Transforms/BtorLiveness.cpp
@@ -47,6 +47,9 @@ LogicalResult replaceWithWriteInPlace(btor::WriteOp &op) {
         op.value(), op.base(), op.index());
       iteOpResult.replaceAllUsesWith(iteWriteInPlaceOp);
       assert(iteOpResult.use_empty());
+      assert(useOp->use_empty());
+      useOp->erase();
+      assert(opPtr->use_empty());
     } else {
       m_builder.setInsertionPointAfterValue(resValue);
       assert(opsMatch(useOp, mlir::BranchOp::getOperationName()));


### PR DESCRIPTION
We transform btor.write under one of two patterns (based on whether the result is live):
1) Conditional write
```
w1 = write v1, A[i1]
ite1 = ite c1, w1, A
```
is replaced with `ite_write_in_place c1, v1, A, i1`

2) Write in place
```
w1 = write v1, A[i1]
return w1
```
is replaced with `write_in_place v1, A, i1`.

The examples below illustrate both of these patterns. Consider a file, `array.mlir` below:
```
module {
  func @main() {
    %0 = btor.constant 1 : i4 !btor.bv<4>
    %1 = btor.array %0 : !btor.array<<4>, <4>>
    br ^bb1(%1, %1 : !btor.array<<4>, <4>>, !btor.array<<4>, <4>>)
  ^bb1(%2: !btor.array<<4>, <4>>, %20: !btor.array<<4>, <4>>):  // 2 preds: ^bb0, ^bb1
    %3 = btor.constant 1 : i4 !btor.bv<4>
    %4 = btor.constant -8 : i4 !btor.bv<4>
    %5 = btor.read %2[%4] : !btor.array<<4>, <4>>, !btor.bv<4>
    %6 = btor.add %5, %3 : !btor.bv<4>
    %7 = btor.write %6, %2[%4] : !btor.array<<4>, <4>>
    %8 = btor.constant -1 : i4 !btor.bv<4>
    %9 = btor.cmp eq, %5, %8 : !btor.bv<4>
    %10 = btor.ite %9, %2, %7 : !btor.array<<4>, <4>>
    %11 = btor.read %2[%4] : !btor.array<<4>, <4>>, !btor.bv<4>
    %14 = btor.write %6, %20[%4] : !btor.array<<4>, <4>>
    %15 = btor.read %20[%4] : !btor.array<<4>, <4>>, !btor.bv<4>
    btor.assert_not(%9), 0 : i64 !btor.bv<1>
    br ^bb1(%10, %14 : !btor.array<<4>, <4>>, !btor.array<<4>, <4>>)
  }
}
```
We can get the transformed code using .`/btor2mlir-opt --btor-liveness array.mlir`:
```
module {
  func @main() {
    %0 = btor.constant 1 : i4 !btor.bv<4>
    %1 = btor.array %0 : !btor.array<<4>, <4>>
    br ^bb1(%1, %1 : !btor.array<<4>, <4>>, !btor.array<<4>, <4>>)
  ^bb1(%2: !btor.array<<4>, <4>>, %3: !btor.array<<4>, <4>>):  // 2 preds: ^bb0, ^bb1
    %4 = btor.constant 1 : i4 !btor.bv<4>
    %5 = btor.constant -8 : i4 !btor.bv<4>
    %6 = btor.read %2[%5] : !btor.array<<4>, <4>>, !btor.bv<4>
    %7 = btor.add %6, %4 : !btor.bv<4>
    %8 = btor.constant -1 : i4 !btor.bv<4>
    %9 = btor.cmp eq, %6, %8 : !btor.bv<4>
    %10 = btor.read %2[%5] : !btor.array<<4>, <4>>, !btor.bv<4>
    %11 = btor.write %7, %2[%5] : !btor.array<<4>, <4>>
    %12 = btor.ite_write_in_place %9, %7, %2[%5] : !btor.array<<4>, <4>>
    %13 = btor.read %3[%5] : !btor.array<<4>, <4>>, !btor.bv<4>
    %14 = btor.write %7, %3[%5] : !btor.array<<4>, <4>>
    %15 = btor.write_in_place %7, %3[%5] : !btor.array<<4>, <4>>
    btor.assert_not(%9), 0 : i64 !btor.bv<1>
    br ^bb1(%12, %15 : !btor.array<<4>, <4>>, !btor.array<<4>, <4>>)
  }
}
```
Where every:

- read of a base array happens before the write in place
- original write operation is replaced with the transformed write